### PR TITLE
createdAt 수동 설정하기 

### DIFF
--- a/src/main/java/boombimapi/domain/alarm/domain/entity/alarm/Alarm.java
+++ b/src/main/java/boombimapi/domain/alarm/domain/entity/alarm/Alarm.java
@@ -49,7 +49,6 @@ public class Alarm {
     @Column(nullable = false)
     private AlarmStatus status;
 
-    @CreationTimestamp
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
@@ -75,5 +74,12 @@ public class Alarm {
     public void updateFailureReason(String failureReason) {
         this.status = AlarmStatus.FAILED;
         this.failureReason = failureReason;
+    }
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now(); // 한국시간
+        }
+
     }
 }

--- a/src/main/java/boombimapi/domain/alarm/domain/entity/alarm/AlarmRecipient.java
+++ b/src/main/java/boombimapi/domain/alarm/domain/entity/alarm/AlarmRecipient.java
@@ -43,7 +43,7 @@ public class AlarmRecipient {
     @Column(columnDefinition = "TEXT")
     private String failureReason;
 
-    @CreationTimestamp
+
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -51,15 +51,30 @@ public class AlarmRecipient {
     public AlarmRecipient(Alarm alarm, Member member, DeviceType deviceType) {
         this.alarm = alarm;
         this.member = member;
-        this.deviceType=deviceType;
+        this.deviceType = deviceType;
     }
 
-    public void markSent() { this.deliveryStatus = DeliveryStatus.SENT; this.sentAt = LocalDateTime.now(); }
-    public void markFailed(String reason) { this.deliveryStatus = DeliveryStatus.FAILED; this.failureReason = reason; }
+    public void markSent() {
+        this.deliveryStatus = DeliveryStatus.SENT;
+        this.sentAt = LocalDateTime.now();
+    }
+
+    public void markFailed(String reason) {
+        this.deliveryStatus = DeliveryStatus.FAILED;
+        this.failureReason = reason;
+    }
 
     // 읽음 처리
-    public void updateDeliveryStatus(){
-        this.deliveryStatus=DeliveryStatus.READ;
+    public void updateDeliveryStatus() {
+        this.deliveryStatus = DeliveryStatus.READ;
+    }
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now(); // 한국시간
+        }
+
     }
 
 }

--- a/src/main/java/boombimapi/domain/alarm/domain/entity/fcm/FcmToken.java
+++ b/src/main/java/boombimapi/domain/alarm/domain/entity/fcm/FcmToken.java
@@ -20,7 +20,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class FcmToken {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     // 연관관계 매핑: FK 컬럼 member_id
@@ -35,8 +36,7 @@ public class FcmToken {
     @Column(nullable = false)
     private DeviceType deviceType;
 
-    @CreationTimestamp
-    @Column(nullable = false, updatable = false)
+    @Column(nullable = false)
     private LocalDateTime createdAt;
 
     @Column(nullable = false)
@@ -53,8 +53,25 @@ public class FcmToken {
         this.lastUsedAt = LocalDateTime.now();
     }
 
-    public void updateLastUsedAt() { this.lastUsedAt = LocalDateTime.now(); }
-    public void deactivate() { this.isActive = false; }
-    public void activate() { this.isActive = true; updateLastUsedAt(); }
+    public void updateLastUsedAt() {
+        this.lastUsedAt = LocalDateTime.now();
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    public void activate() {
+        this.isActive = true;
+        updateLastUsedAt();
+    }
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now(); // 한국시간
+        }
+
+    }
 }
 

--- a/src/main/java/boombimapi/domain/member/domain/entity/Member.java
+++ b/src/main/java/boombimapi/domain/member/domain/entity/Member.java
@@ -66,7 +66,6 @@ public class Member {
     @Column(name = "social_provider", nullable = false)
     private SocialProvider socialProvider;
 
-    @CreationTimestamp
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
@@ -106,5 +105,13 @@ public class Member {
     public void updateName(String name) {
         this.name=name;
         this.nameFlag=true;
+    }
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now(); // 한국시간
+        }
+
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: prod
+    active: dev

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: dev
+    active: prod


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #33 

## 📝작업 내용

서울로 설정하고 mysql은 이상없는데 postgresql이 한국으로 설정이 안되더라고요
그래서 createdAt 수동으로 설정했습니다. 

   ` @PrePersist
    void onCreate() {
        if (createdAt == null) {
            createdAt = LocalDateTime.now(); // 한국시간
        }
    }`

위와 같이 엔티티 생성하기 전에 직접 설정했습니다. 


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?