### PR TITLE
Refactor#41 mypage api 개선하기

### DIFF
--- a/src/main/java/boombimapi/domain/alarm/application/service/AlarmService.java
+++ b/src/main/java/boombimapi/domain/alarm/application/service/AlarmService.java
@@ -32,7 +32,8 @@ public interface AlarmService {
     SendAlarmResponse sendEndVoteAlarm(Vote vote, List<Member> userList, boolean flag);
 
     // 알림 상태 업데이트 읽었는지 안읽었는지
-    void updateAlarmStatus(String userId, UpdateAlarmStatusReq req);
+    void updateAlarmRead(String userId, UpdateAlarmStatusReq req);
+    void updateAlarmStatus(String userId);
 
 
 }

--- a/src/main/java/boombimapi/domain/alarm/application/service/impl/AlarmServiceImpl.java
+++ b/src/main/java/boombimapi/domain/alarm/application/service/impl/AlarmServiceImpl.java
@@ -235,7 +235,7 @@ public class AlarmServiceImpl implements AlarmService {
     }
 
     @Override
-    public void updateAlarmStatus(String userId, UpdateAlarmStatusReq req) {
+    public void updateAlarmRead(String userId, UpdateAlarmStatusReq req) {
         Member member = userRepository.findById(userId)
                 .orElseThrow(() -> new BoombimException(ErrorCode.USER_NOT_EXIST));
 
@@ -246,6 +246,16 @@ public class AlarmServiceImpl implements AlarmService {
             throw new BoombimException(ErrorCode.ALARM_ACCESS_DENIED);
 
         ar.updateDeliveryStatus();
+    }
+
+    @Override
+    public void updateAlarmStatus(String userId) {
+        Member member = userRepository.findById(userId)
+                .orElseThrow(() -> new BoombimException(ErrorCode.USER_NOT_EXIST));
+
+        if(member.isAlarmFlag()) member.updateIsDeactivateAlarmFlag(); // 알림끔
+        else member.updateIsActivateAlarmFlag(); // 알림킴
+
     }
 
 

--- a/src/main/java/boombimapi/domain/alarm/domain/repository/FcmTokenRepository.java
+++ b/src/main/java/boombimapi/domain/alarm/domain/repository/FcmTokenRepository.java
@@ -18,15 +18,15 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
     // 사용자별 활성화된 토큰 조회
     List<FcmToken> findByMemberIdAndIsActiveTrue(String userId);
 
-    // 모든 활성화된 토큰 조회 (전체 알림용) - alarmFlag가 false인 유저만
-    @Query("SELECT f FROM FcmToken f WHERE f.isActive = true AND f.member.alarmFlag = false")
+    // 모든 활성화된 토큰 조회 (전체 알림용) - alarmFlag가 true인 유저만
+    @Query("SELECT f FROM FcmToken f WHERE f.isActive = true AND f.member.alarmFlag = true")
     List<FcmToken> findAllActiveTokens();
 
-    // 투표 종료 유저 알림용 - alarmFlag가 false인 유저만
+    // 투표 종료 유저 알림용 - alarmFlag가 true인 유저만
     @Query("SELECT f FROM FcmToken f " +
             "WHERE f.member IN :users " +
             "AND f.isActive = true " +
-            "AND f.member.alarmFlag = false " +
+            "AND f.member.alarmFlag = true " +
             "ORDER BY f.member.id ASC, f.lastUsedAt DESC")
     List<FcmToken> findActiveTokensForUsers(@Param("users") List<Member> users);
 

--- a/src/main/java/boombimapi/domain/alarm/presentation/controller/AlarmController.java
+++ b/src/main/java/boombimapi/domain/alarm/presentation/controller/AlarmController.java
@@ -85,11 +85,23 @@ public class AlarmController {
             @ApiResponse(responseCode = "404", description = "알림 및 유저 존재하지 않음"),
     })
     @PatchMapping
-    public void updateAlarmStatus(
+    public void updateAlarmRead(
             @AuthenticationPrincipal String userId,
             @RequestBody UpdateAlarmStatusReq req
     ) {
-        alarmService.updateAlarmStatus(userId, req);
+        alarmService.updateAlarmRead(userId, req);
+    }
+
+    @Operation(summary = "알림 설정 활성화", description = "알림을 활성화 및 비활성화를 합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "유저 존재하지 않음"),
+    })
+    @PatchMapping("/status")
+    public void updateAlarmStatus(
+            @AuthenticationPrincipal String userId
+    ) {
+        alarmService.updateAlarmStatus(userId);
     }
 
 

--- a/src/main/java/boombimapi/domain/member/application/service/impl/MemberServiceImpl.java
+++ b/src/main/java/boombimapi/domain/member/application/service/impl/MemberServiceImpl.java
@@ -81,8 +81,11 @@ public class MemberServiceImpl implements MemberService {
             // 총 투표수
             Long voteALlCnt = vote4Answer.get(0) + vote4Answer.get(1) + vote4Answer.get(2) + vote4Answer.get(3);
 
-            bottomResult.add(MPVoteRes.of(vote.getId(), vote.getCreatedAt(), posName, voteAnswerTypes,
-                    vote4Answer.get(0),vote4Answer.get(1),vote4Answer.get(2),vote4Answer.get(3), voteALlCnt, vote.getVoteStatus()));
+            // 상위 3건 유저 프로필 사진
+            List<String> profile = profileTopThree(vote);
+
+            bottomResult.add(MPVoteRes.of(vote.getId(), profile, vote.getCreatedAt(), posName, voteAnswerTypes,
+                    vote4Answer.get(0), vote4Answer.get(1), vote4Answer.get(2), vote4Answer.get(3), voteALlCnt, vote.getVoteStatus()));
         }
 
         if (bottomResult.isEmpty()) {
@@ -118,8 +121,11 @@ public class MemberServiceImpl implements MemberService {
             // 총 투표수
             Long voteALlCnt = vote4Answer.get(0) + vote4Answer.get(1) + vote4Answer.get(2) + vote4Answer.get(3);
 
-            bottomResult.add(MPVoteRes.of(vote.getId(), vote.getCreatedAt(), posName, voteAnswerTypes,
-                    vote4Answer.get(0),vote4Answer.get(1),vote4Answer.get(2),vote4Answer.get(3), voteALlCnt, vote.getVoteStatus()));
+            // 상위 3건 유저 프로필 사진
+            List<String> profile = profileTopThree(vote);
+
+            bottomResult.add(MPVoteRes.of(vote.getId(), profile, vote.getCreatedAt(), posName, voteAnswerTypes,
+                    vote4Answer.get(0), vote4Answer.get(1), vote4Answer.get(2), vote4Answer.get(3), voteALlCnt, vote.getVoteStatus()));
 
         }
 
@@ -139,8 +145,11 @@ public class MemberServiceImpl implements MemberService {
             // 총 투표수
             Long voteALlCnt = vote4Answer.get(0) + vote4Answer.get(1) + vote4Answer.get(2) + vote4Answer.get(3);
 
-            bottomResult.add(MPVoteRes.of(vote.getId(), vote.getCreatedAt(), posName, voteAnswerTypes,
-                    vote4Answer.get(0),vote4Answer.get(1),vote4Answer.get(2),vote4Answer.get(3), voteALlCnt, vote.getVoteStatus()));
+            // 상위 3건 유저 프로필 사진
+            List<String> profile = profileTopThree(vote);
+
+            bottomResult.add(MPVoteRes.of(vote.getId(), profile, vote.getCreatedAt(), posName, voteAnswerTypes,
+                    vote4Answer.get(0), vote4Answer.get(1), vote4Answer.get(2), vote4Answer.get(3), voteALlCnt, vote.getVoteStatus()));
         }
 
 
@@ -257,5 +266,15 @@ public class MemberServiceImpl implements MemberService {
         result.add(crowdedCount);
         return result;
     }
+
+    // 상위 3건 유저 프로필 이미지 링크
+    public List<String> profileTopThree(Vote vote) {
+        return vote.getVoteAnswers().stream()
+                .map(voteAnswer -> voteAnswer.getMember().getProfile()) // Member의 프로필 URL 추출
+                .filter(Objects::nonNull)                               // null 값 제거 (안전)
+                .limit(3)                                               // 최대 3개만
+                .toList();
+    }
+
 
 }

--- a/src/main/java/boombimapi/domain/member/domain/entity/Member.java
+++ b/src/main/java/boombimapi/domain/member/domain/entity/Member.java
@@ -104,6 +104,9 @@ public class Member {
 
     public void updateName(String name) {
         this.name=name;
+    }
+
+    public void updateIsActivateNameFlag() {
         this.nameFlag=true;
     }
 

--- a/src/main/java/boombimapi/domain/member/domain/entity/Member.java
+++ b/src/main/java/boombimapi/domain/member/domain/entity/Member.java
@@ -76,7 +76,7 @@ public class Member {
     // 관리자 비번 null이어도됨
     private String password;
 
-    // false면 알림감 true면 알림 안감
+    // false면 알림끔 true면 알림 감
     @Column(name = "alarm_flag", nullable = false)
     private boolean alarmFlag;
 
@@ -93,7 +93,7 @@ public class Member {
         this.profile = profile;
         this.socialProvider = socialProvider;
         this.role = role;
-        this.alarmFlag = false;
+        this.alarmFlag = true;
         this.nameFlag = false;
     }
 
@@ -108,6 +108,13 @@ public class Member {
 
     public void updateIsActivateNameFlag() {
         this.nameFlag=true;
+    }
+
+    public void updateIsActivateAlarmFlag() {
+        this.alarmFlag=true;
+    }
+    public void updateIsDeactivateAlarmFlag() {
+        this.alarmFlag=false;
     }
 
     @PrePersist

--- a/src/main/java/boombimapi/domain/member/presentation/controller/MemberController.java
+++ b/src/main/java/boombimapi/domain/member/presentation/controller/MemberController.java
@@ -37,7 +37,7 @@ public class MemberController {
     }
 
 
-    @Operation(summary = "첫 닉네임 수정 API", description = "처음 로그인 할 시 닉네임 수정 화면 뜨는지 안뜨는지 확인하는 API 입니다.")
+    @Operation(summary = "[폐기 - 로그인으로 통합] 첫 닉네임 호출 수정 API", description = "처음 로그인 할 시 닉네임 수정 화면 뜨는지 안뜨는지 확인하는 API 입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "사용자 조회 성공"),
             @ApiResponse(responseCode = "404", description = "유저 존재하지 않음")

--- a/src/main/java/boombimapi/domain/member/presentation/dto/member/res/mypage/MPVoteRes.java
+++ b/src/main/java/boombimapi/domain/member/presentation/dto/member/res/mypage/MPVoteRes.java
@@ -1,8 +1,13 @@
 package boombimapi.domain.member.presentation.dto.member.res.mypage;
 
+import boombimapi.domain.alarm.domain.entity.alarm.type.AlarmStatus;
+import boombimapi.domain.alarm.domain.entity.alarm.type.AlarmType;
+import boombimapi.domain.vote.domain.entity.type.VoteAnswerType;
+import boombimapi.domain.vote.domain.entity.type.VoteStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Schema(description = "마이페이지 개별 투표 응답")
 public record MPVoteRes(
@@ -17,12 +22,50 @@ public record MPVoteRes(
         String posName,
 
         @Schema(description = "가장 많이 투표된 상태 (없음 포함)", example = "CROWED")
-        String popularStatus,
+        List<VoteAnswerType> popularRes,
 
+        @Schema(description = "여유 투표 수", example = "5")
+        Long relaxedCnt,
+
+        @Schema(description = "보통 투표 수", example = "8")
+        Long commonly,
+
+        @Schema(description = "약간 붐빔 투표 수", example = "4")
+        Long slightlyBusyCnt,
+
+        @Schema(description = "붐빔 투표 수", example = "2")
+        Long crowedCnt,
+
+        @Schema(description = "해당 투표 전체 수", example = "18")
+        Long voteAllCnt,
         @Schema(description = "해당 상태의 투표 수", example = "18")
-        Long popularCnt
+        VoteStatus voteStatus
+
+
 ) {
-    public static MPVoteRes of(Long voteId, LocalDateTime day, String posName, String popularStatus, Long popularCnt) {
-        return new MPVoteRes(voteId, day, posName, popularStatus, popularCnt);
+    public static MPVoteRes of(
+            Long voteId,
+            LocalDateTime day,
+            String posName,
+            List<VoteAnswerType> popularRes,
+            Long relaxedCnt,
+            Long commonly,
+            Long slightlyBusyCnt,
+            Long crowedCnt,
+            Long voteAllCnt,
+            VoteStatus voteStatus
+    ) {
+        return new MPVoteRes(
+                voteId,
+                day,
+                posName,
+                popularRes,
+                relaxedCnt,
+                commonly,
+                slightlyBusyCnt,
+                crowedCnt,
+                voteAllCnt,
+                voteStatus
+        );
     }
 }

--- a/src/main/java/boombimapi/domain/member/presentation/dto/member/res/mypage/MPVoteRes.java
+++ b/src/main/java/boombimapi/domain/member/presentation/dto/member/res/mypage/MPVoteRes.java
@@ -15,6 +15,9 @@ public record MPVoteRes(
         @Schema(description = "투표 ID", example = "101")
         Long voteId,
 
+        @Schema(description = "사용자 별 프로필 사진", example = "http://k.kakaocdn.net/dn/bN0Hg2/btsIUhLSYs8/vrWzldpNSnycWKkRtYyIgk/img_640x640.jpg")
+        List<String> profile,
+
         @Schema(description = "투표 생성 시간", example = "2025-07-15T09:30:00")
         LocalDateTime day,
 
@@ -45,6 +48,7 @@ public record MPVoteRes(
 ) {
     public static MPVoteRes of(
             Long voteId,
+            List<String> profile,
             LocalDateTime day,
             String posName,
             List<VoteAnswerType> popularRes,
@@ -57,6 +61,7 @@ public record MPVoteRes(
     ) {
         return new MPVoteRes(
                 voteId,
+                profile,
                 day,
                 posName,
                 popularRes,

--- a/src/main/java/boombimapi/domain/oauth2/application/service/impl/CreateAccessTokenAndRefreshTokenServiceImpl.java
+++ b/src/main/java/boombimapi/domain/oauth2/application/service/impl/CreateAccessTokenAndRefreshTokenServiceImpl.java
@@ -1,8 +1,12 @@
 package boombimapi.domain.oauth2.application.service.impl;
 
+import boombimapi.domain.member.domain.entity.Member;
+import boombimapi.domain.member.domain.repository.MemberRepository;
 import boombimapi.domain.oauth2.application.service.CreateAccessTokenAndRefreshTokenService;
 import boombimapi.domain.oauth2.presentation.dto.res.LoginToken;
 import boombimapi.domain.member.domain.entity.Role;
+import boombimapi.global.infra.exception.error.BoombimException;
+import boombimapi.global.infra.exception.error.ErrorCode;
 import boombimapi.global.jwt.domain.entity.JsonWebToken;
 import boombimapi.global.jwt.domain.repository.JsonWebTokenRepository;
 import boombimapi.global.jwt.util.JWTUtil;
@@ -19,6 +23,7 @@ public class CreateAccessTokenAndRefreshTokenServiceImpl implements CreateAccess
 
     private final JWTUtil jwtUtil;
     private final JsonWebTokenRepository jsonWebTokenRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     public LoginToken createAccessTokenAndRefreshToken(String userId, Role role, String email) {
@@ -34,6 +39,14 @@ public class CreateAccessTokenAndRefreshTokenServiceImpl implements CreateAccess
 
         jsonWebTokenRepository.save(jsonWebToken);
 
-        return LoginToken.of(accessToken, refreshToken);
+        boolean nameFlag = onBoarding(userId);
+        return LoginToken.of(accessToken, refreshToken, nameFlag);
+    }
+
+    public boolean onBoarding(String userId) {
+        Member member = memberRepository.findById(userId).orElse(null);
+        if (member == null) throw new BoombimException(ErrorCode.USER_NOT_EXIST);
+
+        return member.isNameFlag();
     }
 }

--- a/src/main/java/boombimapi/domain/oauth2/application/service/impl/auth/ReissueServiceImpl.java
+++ b/src/main/java/boombimapi/domain/oauth2/application/service/impl/auth/ReissueServiceImpl.java
@@ -1,5 +1,7 @@
 package boombimapi.domain.oauth2.application.service.impl.auth;
 
+import boombimapi.domain.member.domain.entity.Member;
+import boombimapi.domain.member.domain.repository.MemberRepository;
 import boombimapi.domain.oauth2.application.service.ReissueService;
 import boombimapi.domain.oauth2.presentation.dto.res.LoginToken;
 import boombimapi.domain.member.domain.entity.Role;
@@ -21,6 +23,7 @@ public class ReissueServiceImpl implements ReissueService {
 
     private final JWTUtil jwtUtil;
     private final JsonWebTokenRepository jsonWebTokenRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     public LoginToken reissue(String refreshToken) {
@@ -53,6 +56,13 @@ public class ReissueServiceImpl implements ReissueService {
         jsonWebTokenRepository.save(newJsonWebToken);
 
 
-        return LoginToken.of(newAccessToken, newRefreshToken);
+        return LoginToken.of(newAccessToken, newRefreshToken, onBoarding(userId));
+    }
+
+    public boolean onBoarding(String userId) {
+        Member member = memberRepository.findById(userId).orElse(null);
+        if (member == null) throw new BoombimException(ErrorCode.USER_NOT_EXIST);
+
+        return member.isNameFlag();
     }
 }

--- a/src/main/java/boombimapi/domain/oauth2/application/service/impl/oauth/SocialLoginServiceImpl.java
+++ b/src/main/java/boombimapi/domain/oauth2/application/service/impl/oauth/SocialLoginServiceImpl.java
@@ -210,6 +210,7 @@ public class SocialLoginServiceImpl implements SocialLoginService {
             }
             log.info("기존 {} 사용자 정보 업데이트: {}", provider, userResponse.getName());
             user.updateEmailAndProfile(userResponse.getEmail(), userResponse.getProfile());
+            user.updateIsActivateNameFlag();
         }
 
         saveSocialToken(user.getId(), provider, tokenResponse);

--- a/src/main/java/boombimapi/domain/oauth2/presentation/controller/SocialLoginController.java
+++ b/src/main/java/boombimapi/domain/oauth2/presentation/controller/SocialLoginController.java
@@ -20,7 +20,7 @@ public class SocialLoginController {
 
     private final SocialLoginService socialLoginService;
 
-    @Operation(summary = "소셜 로그인 URL 조회", description = "각 플랫폼별 소셜 로그인 URL을 반환합니다. (테스트용)")
+    @Operation(summary = "[테스트 용] 소셜 로그인 URL 조회", description = "각 플랫폼별 소셜 로그인 URL을 반환합니다. (테스트용)")
     @GetMapping("/login/{provider}")
     public ResponseEntity<String> getLoginUrl(@PathVariable SocialProvider provider) {
         log.info("소셜 로그인 URL 요청: {}", provider);
@@ -45,7 +45,7 @@ public class SocialLoginController {
     }
 
     // 기존 콜백 방식은 테스트용으로 유지 (필요시 제거 가능)
-    @Operation(summary = "소셜 로그인 콜백 (테스트용)", description = "테스트용 콜백 API")
+    @Operation(summary = "[테스트 용] 소셜 로그인 콜백", description = "테스트용 콜백 API")
     @GetMapping("/callback/{provider}")
     public ResponseEntity<LoginToken> socialLogin(
             @PathVariable SocialProvider provider,
@@ -56,7 +56,7 @@ public class SocialLoginController {
         return ResponseEntity.ok(loginToken);
     }
 
-    @Operation(summary = "소셜 로그인 콜백 (테스트용)", description = "테스트용 콜백 API")
+    @Operation(summary = "[테스트 용] 소셜 로그인 콜백", description = "테스트용 콜백 API")
     @PostMapping("/callback/apple")
     public ResponseEntity<LoginToken> socialAppleLogin(
             @RequestParam("code") String code) {

--- a/src/main/java/boombimapi/domain/oauth2/presentation/dto/res/LoginToken.java
+++ b/src/main/java/boombimapi/domain/oauth2/presentation/dto/res/LoginToken.java
@@ -9,10 +9,13 @@ public record LoginToken(
         String accessToken,
 
         @Schema(description = "JWT 리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
-        String refreshToken
+        String refreshToken,
+
+        @Schema(description = "접속해서 닉네임 수정 호출할지, 즉 false면 호출해야됨", example = "false, true")
+        boolean nameFlag
 
 ) {
-    public static LoginToken of(String accessToken, String refreshToken) {
-        return new LoginToken(accessToken, refreshToken);
+    public static LoginToken of(String accessToken, String refreshToken, boolean nameFlag) {
+        return new LoginToken(accessToken, refreshToken, nameFlag);
     }
 }

--- a/src/main/java/boombimapi/domain/vote/presentation/dto/res/list/MyVoteRes.java
+++ b/src/main/java/boombimapi/domain/vote/presentation/dto/res/list/MyVoteRes.java
@@ -4,12 +4,15 @@ import boombimapi.domain.vote.domain.entity.type.VoteStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Schema(description = "내 질문 리스트 응답 DTO")
 public record MyVoteRes(
 
         @Schema(description = "투표 ID", example = "1")
         Long voteId,
+        @Schema(description = "사용자 별 프로필 사진", example = "http://k.kakaocdn.net/dn/bN0Hg2/btsIUhLSYs8/vrWzldpNSnycWKkRtYyIgk/img_640x640.jpg")
+        List<String> profile,
 
         @Schema(description = "투표 중복자 수 (궁금해하는 사람 수)", example = "3")
         Long voteDuplicationCnt,
@@ -42,9 +45,9 @@ public record MyVoteRes(
         boolean voteFlag
 
 ) {
-    public static MyVoteRes of(Long voteId, Long voteDuplicationCnt, LocalDateTime createdAt, String posName, Long relaxedCnt,
+    public static MyVoteRes of(Long voteId, List<String> profile, Long voteDuplicationCnt, LocalDateTime createdAt, String posName, Long relaxedCnt,
                                Long commonly, Long slightlyBusyCnt, Long crowedCnt, String allType, VoteStatus voteStatus, boolean voteFlag) {
-        return new MyVoteRes(voteId, voteDuplicationCnt, createdAt, posName, relaxedCnt,
+        return new MyVoteRes(voteId, profile, voteDuplicationCnt, createdAt, posName, relaxedCnt,
                 commonly, slightlyBusyCnt, crowedCnt, allType, voteStatus, voteFlag);
     }
 }

--- a/src/main/java/boombimapi/domain/vote/presentation/dto/res/list/VoteRes.java
+++ b/src/main/java/boombimapi/domain/vote/presentation/dto/res/list/VoteRes.java
@@ -3,13 +3,15 @@ package boombimapi.domain.vote.presentation.dto.res.list;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Schema(description = "전체 투표 목록 응답 DTO(500M)")
 public record VoteRes(
 
         @Schema(description = "투표 ID", example = "1")
         Long voteId,
-
+        @Schema(description = "사용자 별 프로필 사진", example = "http://k.kakaocdn.net/dn/bN0Hg2/btsIUhLSYs8/vrWzldpNSnycWKkRtYyIgk/img_640x640.jpg")
+        List<String> profile,
         @Schema(description = "투표 중복자 수 (궁금해하는 사람 수)", example = "3")
         Long voteDuplicationCnt,
 
@@ -37,10 +39,10 @@ public record VoteRes(
         @Schema(description = "투표했으면 true, 안했으면 false", example = "true")
         boolean voteFlag
 ) {
-    public static VoteRes of(Long voteId, Long voteDuplicationCnt, LocalDateTime createdAt,
+    public static VoteRes of(Long voteId, List<String> profile, Long voteDuplicationCnt, LocalDateTime createdAt,
                              String posName, Long relaxedCnt, Long commonly, Long slightlyBusyCnt,
                              Long crowedCnt, String allType, boolean voteFlag) {
-        return new VoteRes(voteId, voteDuplicationCnt, createdAt, posName, relaxedCnt,
+        return new VoteRes(voteId, profile, voteDuplicationCnt, createdAt, posName, relaxedCnt,
                 commonly, slightlyBusyCnt, crowedCnt, allType, voteFlag);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #41 

## 📝작업 내용

> 마이페이지 응답값 인기 타입 리스트 형태, 소통방과 동일하게 각각의 투표수, 그리고 유저 프로필 사진 추가했습니다.
> 소통방 응답 구간에서도 유저 프로필 추가했습니다.
> 닉넴임 첫 호출 화면 API 없애고 로그인 했을떄 LoginToken 응답값에 nameFlag 설정했습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?