### PR TITLE
[Refactor] 특정 공식 장소 정보 조회 시 관측 시각 응답에 추가 및 사용자 장소 도메인에 Swagger 활성화

### DIFF
--- a/src/main/java/boombimapi/domain/place/api/MemberPlaceController.java
+++ b/src/main/java/boombimapi/domain/place/api/MemberPlaceController.java
@@ -8,6 +8,10 @@ import boombimapi.domain.place.dto.request.ViewportRequest;
 import boombimapi.domain.place.dto.response.ResolveMemberPlaceResponse;
 import boombimapi.domain.place.dto.response.node.ViewportNodeResponse;
 import boombimapi.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,10 +24,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/member-place")
+@Tag(name = "Member Place", description = "사용자 장소 관련 API")
 public class MemberPlaceController {
 
     private final MemberPlaceService memberPlaceService;
 
+    @Operation(summary = "사용자 장소 등록 및 등록 여부 확인", description = "사용자가 혼잡도를 등록하려는 장소가 이미 서버 단에 저장이 되어있는지 확인합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "사용자 장소 확인 성공")
+    })
     @PostMapping("/resolve")
     public ResponseEntity<BaseResponse<ResolveMemberPlaceResponse>> resolveMemberPlace(
         @RequestBody ResolveMemberPlaceRequest request
@@ -37,6 +46,10 @@ public class MemberPlaceController {
         );
     }
 
+    @Operation(summary = "뷰포트 내 사용자 장소 조회", description = "뷰포트 내 사용자 장소들 중 1시간 내 작성된 혼잡도가 존재하는 장소들을 리스트로 반환합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "뷰포트 내 사용자 장소 조회 성공")
+    })
     @PostMapping
     public ResponseEntity<BaseResponse<List<ViewportNodeResponse>>> getMemberPlacesInViewport(
         @RequestBody ViewportRequest request
@@ -49,8 +62,5 @@ public class MemberPlaceController {
             )
         );
     }
-
-//    @GetMapping("/{memberPlaceId}")
-//    public ResponseEntity<BaseResponse<>>
 
 }

--- a/src/main/java/boombimapi/domain/place/application/MemberPlaceService.java
+++ b/src/main/java/boombimapi/domain/place/application/MemberPlaceService.java
@@ -118,15 +118,15 @@ public class MemberPlaceService {
                 Map<String, Integer> levelCounts = new HashMap<>();
 
                 for (Long placeId : clusterMarker.memberPlaceIds()) {
-                    Optional<MemberCongestion> memberCongestionOptional =
+                    Optional<MemberCongestion> optionalMemberCongestion =
                         memberCongestionRepository.findFirstByMemberPlaceIdAndExpiresAtAfterOrderByCreatedAtDesc(
                             placeId, now
                         );
 
-                    if (memberCongestionOptional.isEmpty())
+                    if (optionalMemberCongestion.isEmpty())
                         continue;
 
-                    String levelName = memberCongestionOptional.get().getCongestionLevel().getName();
+                    String levelName = optionalMemberCongestion.get().getCongestionLevel().getName();
                     levelCounts.merge(levelName, 1, Integer::sum);
                 }
 
@@ -147,15 +147,15 @@ public class MemberPlaceService {
                 if (memberPlace == null)
                     continue;
 
-                Optional<MemberCongestion> memberCongestionOptional =
+                Optional<MemberCongestion> optionalMemberCongestion =
                     memberCongestionRepository.findFirstByMemberPlaceIdAndExpiresAtAfterOrderByCreatedAtDesc(
                         placeId, now
                     );
 
-                if (memberCongestionOptional.isEmpty())
+                if (optionalMemberCongestion.isEmpty())
                     continue;
 
-                MemberCongestion memberCongestion = memberCongestionOptional.get();
+                MemberCongestion memberCongestion = optionalMemberCongestion.get();
 
                 double distanceMeters = GeoDistance.haversineMeters(
                     memberLatitude,

--- a/src/main/java/boombimapi/domain/place/application/OfficialPlaceService.java
+++ b/src/main/java/boombimapi/domain/place/application/OfficialPlaceService.java
@@ -134,6 +134,7 @@ public class OfficialPlaceService {
             officialPlace.getId(),
             officialPlace.getName(),
             officialPlace.getPoiCode(),
+            latestOfficialCongestion.getObservedAt(),
             officialPlace.getCentroidLatitude(),
             officialPlace.getCentroidLongitude(),
             officialPlace.getPolygonCoordinates(),

--- a/src/main/java/boombimapi/domain/place/dto/response/official/OfficialPlaceOverviewResponse.java
+++ b/src/main/java/boombimapi/domain/place/dto/response/official/OfficialPlaceOverviewResponse.java
@@ -1,11 +1,13 @@
 package boombimapi.domain.place.dto.response.official;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record OfficialPlaceOverviewResponse(
     Long id,
     String name,
     String poiCode,
+    LocalDateTime observedAt,
     Double centroidLatitude,
     Double centroidLongitude,
     String polygonCoordinates,


### PR DESCRIPTION
## #️⃣연관된 이슈

- #46 

## 📝작업 내용

- 특정 공식 장소의 혼잡도 조회 시 관측 시각을 포함하여 응답을 내려주도록 수정
- 사용자 장소 관련 API에 Swagger 활성화