### PR TITLE
[Feat] 사용자 장소 상세 API 구현 및 무한 스크롤 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ src/main/resources/*.sql
 
 ### application-dev ###
 src/main/resources/application-dev.yml
+
+### env ###
+/env

--- a/src/main/java/boombimapi/domain/congestion/dto/response/MemberCongestionItemResponse.java
+++ b/src/main/java/boombimapi/domain/congestion/dto/response/MemberCongestionItemResponse.java
@@ -1,0 +1,5 @@
+package boombimapi.domain.congestion.dto.response;
+
+public record MemberCongestionItemResponse() {
+
+}

--- a/src/main/java/boombimapi/domain/congestion/dto/response/MemberCongestionItemResponse.java
+++ b/src/main/java/boombimapi/domain/congestion/dto/response/MemberCongestionItemResponse.java
@@ -1,5 +1,24 @@
 package boombimapi.domain.congestion.dto.response;
 
-public record MemberCongestionItemResponse() {
+import boombimapi.domain.congestion.entity.MemberCongestion;
+import java.time.LocalDateTime;
+
+public record MemberCongestionItemResponse(
+    Long memberCongestionId,
+    String congestionLevelName,
+    String congestionLevelMessage,
+    LocalDateTime createdAt
+) {
+
+    public static MemberCongestionItemResponse of(
+        MemberCongestion memberCongestion
+    ) {
+        return new MemberCongestionItemResponse(
+            memberCongestion.getId(),
+            memberCongestion.getCongestionLevel().getName(),
+            memberCongestion.getCongestionMessage(),
+            memberCongestion.getCreatedAt()
+        );
+    }
 
 }

--- a/src/main/java/boombimapi/domain/congestion/repository/MemberCongestionRepository.java
+++ b/src/main/java/boombimapi/domain/congestion/repository/MemberCongestionRepository.java
@@ -5,6 +5,8 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import feign.Param;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -21,11 +23,22 @@ public interface MemberCongestionRepository extends JpaRepository<MemberCongesti
     );
 
     @Query("""
-           SELECT COUNT(mc) 
-           FROM MemberCongestion mc
-           WHERE mc.memberPlace.id = :placeId
-             AND CAST(mc.createdAt AS DATE) = CURRENT_DATE
-           """)
+        SELECT COUNT(mc) 
+        FROM MemberCongestion mc
+        WHERE mc.memberPlace.id = :placeId
+          AND CAST(mc.createdAt AS DATE) = CURRENT_DATE
+        """)
     long countTodayByPlace(@Param("placeId") Long placeId);
+
+    Slice<MemberCongestion> findByMemberPlaceIdOrderByIdDesc(
+        Long memberPlaceId,
+        Pageable pageable
+    );
+
+    Slice<MemberCongestion> findByMemberPlaceIdAndIdLessThanOrderByIdDesc(
+        Long memberPlaceId,
+        Long cursor,
+        Pageable pageable
+    );
 
 }

--- a/src/main/java/boombimapi/domain/place/api/MemberPlaceController.java
+++ b/src/main/java/boombimapi/domain/place/api/MemberPlaceController.java
@@ -5,7 +5,7 @@ import static boombimapi.global.response.ResponseMessage.*;
 import boombimapi.domain.place.application.MemberPlaceService;
 import boombimapi.domain.place.dto.request.ResolveMemberPlaceRequest;
 import boombimapi.domain.place.dto.request.ViewportRequest;
-import boombimapi.domain.place.dto.response.ResolveMemberPlaceResponse;
+import boombimapi.domain.place.dto.response.member.ResolveMemberPlaceResponse;
 import boombimapi.domain.place.dto.response.node.ViewportNodeResponse;
 import boombimapi.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/boombimapi/domain/place/api/MemberPlaceController.java
+++ b/src/main/java/boombimapi/domain/place/api/MemberPlaceController.java
@@ -5,6 +5,7 @@ import static boombimapi.global.response.ResponseMessage.*;
 import boombimapi.domain.place.application.MemberPlaceService;
 import boombimapi.domain.place.dto.request.ResolveMemberPlaceRequest;
 import boombimapi.domain.place.dto.request.ViewportRequest;
+import boombimapi.domain.place.dto.response.member.GetMemberPlaceDetailResponse;
 import boombimapi.domain.place.dto.response.member.ResolveMemberPlaceResponse;
 import boombimapi.domain.place.dto.response.node.ViewportNodeResponse;
 import boombimapi.global.response.BaseResponse;
@@ -12,13 +13,19 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -52,15 +59,45 @@ public class MemberPlaceController {
     })
     @PostMapping
     public ResponseEntity<BaseResponse<List<ViewportNodeResponse>>> getMemberPlacesInViewport(
+        @AuthenticationPrincipal String memberId,
         @RequestBody ViewportRequest request
     ) {
         return ResponseEntity.ok(
             BaseResponse.of(
                 HttpStatus.OK,
                 GET_MEMBER_PLACES_IN_VIEWPORT_SUCCESS,
-                memberPlaceService.getViewportNodes(request)
+                memberPlaceService.getViewportNodes(memberId, request)
             )
         );
+    }
+
+    @Operation(summary = "특정 사용자 장소 상세 조회", description = "특정 사용자 장소를 상세 조회하여 해당 장소에 작성된 혼잡도들을 확인합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "특정 사용자 장소 상세 조회 성공")
+    })
+    @GetMapping("/{memberPlaceId}")
+    public ResponseEntity<BaseResponse<GetMemberPlaceDetailResponse>> getMemberPlaceDetail(
+        @PathVariable Long memberPlaceId,
+        @RequestParam(required = false) @Min(1) @Max(100) Integer size,
+        @RequestParam(required = false) Long cursor,
+        @AuthenticationPrincipal String memberId
+    ) {
+
+        GetMemberPlaceDetailResponse memberPlaceDetailResponse = memberPlaceService.getMemberPlaceDetail(
+            memberId,
+            memberPlaceId,
+            size,
+            cursor
+        );
+
+        return ResponseEntity.ok(
+            BaseResponse.of(
+                HttpStatus.OK,
+                GET_MEMBER_PLACE_DETAIL_SUCCESS,
+                memberPlaceDetailResponse
+            )
+        );
+
     }
 
 }

--- a/src/main/java/boombimapi/domain/place/application/MemberPlaceService.java
+++ b/src/main/java/boombimapi/domain/place/application/MemberPlaceService.java
@@ -4,7 +4,7 @@ import boombimapi.domain.congestion.entity.MemberCongestion;
 import boombimapi.domain.congestion.repository.MemberCongestionRepository;
 import boombimapi.domain.place.dto.request.ResolveMemberPlaceRequest;
 import boombimapi.domain.place.dto.request.ViewportRequest;
-import boombimapi.domain.place.dto.response.ResolveMemberPlaceResponse;
+import boombimapi.domain.place.dto.response.member.ResolveMemberPlaceResponse;
 import boombimapi.domain.place.dto.response.node.ViewportClusterNodeResponse;
 import boombimapi.domain.place.dto.response.node.ViewportNodeResponse;
 import boombimapi.domain.place.dto.response.node.ViewportPlaceNodeResponse;

--- a/src/main/java/boombimapi/domain/place/application/MemberPlaceService.java
+++ b/src/main/java/boombimapi/domain/place/application/MemberPlaceService.java
@@ -1,9 +1,15 @@
 package boombimapi.domain.place.application;
 
+import static boombimapi.global.infra.exception.error.ErrorCode.*;
+
+import boombimapi.domain.congestion.dto.response.MemberCongestionItemResponse;
 import boombimapi.domain.congestion.entity.MemberCongestion;
 import boombimapi.domain.congestion.repository.MemberCongestionRepository;
+import boombimapi.domain.favorite.repository.FavoriteRepository;
 import boombimapi.domain.place.dto.request.ResolveMemberPlaceRequest;
 import boombimapi.domain.place.dto.request.ViewportRequest;
+import boombimapi.domain.place.dto.response.member.GetMemberPlaceDetailResponse;
+import boombimapi.domain.place.dto.response.member.MemberPlaceSummaryResponse;
 import boombimapi.domain.place.dto.response.member.ResolveMemberPlaceResponse;
 import boombimapi.domain.place.dto.response.node.ViewportClusterNodeResponse;
 import boombimapi.domain.place.dto.response.node.ViewportNodeResponse;
@@ -16,6 +22,7 @@ import boombimapi.global.geo.core.ClusterPoint;
 import boombimapi.global.geo.core.Clusterer;
 import boombimapi.global.geo.internal.GeoDistance;
 
+import boombimapi.global.infra.exception.error.BoombimException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,6 +32,9 @@ import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -36,30 +46,77 @@ public class MemberPlaceService {
     private final MemberCongestionRepository memberCongestionRepository;
 
     private final Clusterer clusterer;
+    private final FavoriteRepository favoriteRepository;
 
     public ResolveMemberPlaceResponse resolveMemberPlace(
-            ResolveMemberPlaceRequest request
+        ResolveMemberPlaceRequest request
     ) {
         log.info("[MemberPlaceService] resolveMemberPlace()");
 
-
         // TODO: 레이스 컨디션 처리 필요(동일 uuid 동시 생성 방지)
         MemberPlace memberPlace = memberPlaceRepository.findByUuid(request.uuid())
-                .orElseGet(() -> memberPlaceRepository.save(
-                        MemberPlace.of(
-                                request.uuid(),
-                                request.name(),
-                                request.latitude(),
-                                request.longitude(),
-                                request.imageUrl()
-                        )
-                ));
+            .orElseGet(() -> memberPlaceRepository.save(
+                MemberPlace.of(
+                    request.uuid(),
+                    request.name(),
+                    request.address(),
+                    request.latitude(),
+                    request.longitude(),
+                    request.imageUrl()
+                )
+            ));
 
         return ResolveMemberPlaceResponse.from(memberPlace);
     }
 
+    public GetMemberPlaceDetailResponse getMemberPlaceDetail(
+        String memberId,
+        Long memberPlaceId,
+        Integer size,
+        Long cursor
+    ) {
+        int pageSize = sanitizeSize(size);
+        Pageable pageable = PageRequest.of(0, pageSize);
+
+        MemberPlace memberPlace = memberPlaceRepository.findById(memberPlaceId)
+            .orElseThrow(() -> new BoombimException(MEMBER_PLACE_NOT_FOUND));
+
+        Slice<MemberCongestion> slice = loadMemberCongestionSlice(
+            memberPlaceId,
+            cursor,
+            pageable
+        );
+
+        List<MemberCongestionItemResponse> memberCongestionItems = slice.getContent().stream()
+            .map(MemberCongestionItemResponse::of)
+            .toList();
+
+        Long nextCursor = computeNextCursor(memberCongestionItems);
+
+        boolean isFavorite = isFavorite(memberId, memberPlaceId);
+
+        MemberPlaceSummaryResponse memberPlaceSummary = MemberPlaceSummaryResponse.of(
+            memberPlace.getId(),
+            memberPlace.getName(),
+            memberPlace.getAddress(),
+            memberPlace.getLatitude(),
+            memberPlace.getLongitude(),
+            memberPlace.getImageUrl(),
+            isFavorite
+        );
+
+        return GetMemberPlaceDetailResponse.of(
+            memberPlaceSummary,
+            memberCongestionItems,
+            slice.hasNext(),
+            nextCursor,
+            pageSize
+        );
+    }
+
     public List<ViewportNodeResponse> getViewportNodes(
-            ViewportRequest request
+        String memberId,
+        ViewportRequest request
     ) {
 
         // 1) 뷰포트 경계 계산
@@ -75,7 +132,7 @@ public class MemberPlaceService {
 
         // 2) 뷰포트 내 장소 조회
         List<MemberPlace> allPlaces = memberPlaceRepository
-                .findByLatitudeBetweenAndLongitudeBetween(minLatitude, maxLatitude, minLongitude, maxLongitude);
+            .findByLatitudeBetweenAndLongitudeBetween(minLatitude, maxLatitude, minLongitude, maxLongitude);
 
         // 3) 유효 혼잡도 존재 장소만 필터링
         LocalDateTime now = LocalDateTime.now();
@@ -84,7 +141,7 @@ public class MemberPlaceService {
 
         for (MemberPlace memberPlace : allPlaces) {
             boolean exists = memberCongestionRepository
-                    .existsByMemberPlaceIdAndExpiresAtAfter(memberPlace.getId(), now);
+                .existsByMemberPlaceIdAndExpiresAtAfter(memberPlace.getId(), now);
             if (exists) {
                 clusterPoints.add(new ClusterPoint(memberPlace.getId(), memberPlace.getLatitude(), memberPlace.getLongitude()));
                 memberPlaceMap.put(memberPlace.getId(), memberPlace);
@@ -99,12 +156,12 @@ public class MemberPlaceService {
 
         // Clustering
         List<ClusterMarker> clusterMarkers = clusterer.cluster(
-                clusterPoints,
-                minLatitude,
-                maxLatitude,
-                minLongitude,
-                maxLongitude,
-                zoomLevel
+            clusterPoints,
+            minLatitude,
+            maxLatitude,
+            minLongitude,
+            maxLongitude,
+            zoomLevel
         );
 
         int minClusterSize = 2;
@@ -123,9 +180,9 @@ public class MemberPlaceService {
 
                 for (Long placeId : clusterMarker.memberPlaceIds()) {
                     Optional<MemberCongestion> optionalMemberCongestion =
-                            memberCongestionRepository.findFirstByMemberPlaceIdAndExpiresAtAfterOrderByCreatedAtDesc(
-                                    placeId, now
-                            );
+                        memberCongestionRepository.findFirstByMemberPlaceIdAndExpiresAtAfterOrderByCreatedAtDesc(
+                            placeId, now
+                        );
 
                     if (optionalMemberCongestion.isEmpty())
                         continue;
@@ -135,11 +192,11 @@ public class MemberPlaceService {
                 }
 
                 nodes.add(
-                        ViewportClusterNodeResponse.of(
-                                new Coordinate(clusterMarker.latitude(), clusterMarker.longitude()),
-                                clusterMarker.count(),
-                                levelCounts
-                        )
+                    ViewportClusterNodeResponse.of(
+                        new Coordinate(clusterMarker.latitude(), clusterMarker.longitude()),
+                        clusterMarker.count(),
+                        levelCounts
+                    )
                 );
 
                 continue;
@@ -152,9 +209,9 @@ public class MemberPlaceService {
                     continue;
 
                 Optional<MemberCongestion> optionalMemberCongestion =
-                        memberCongestionRepository.findFirstByMemberPlaceIdAndExpiresAtAfterOrderByCreatedAtDesc(
-                                placeId, now
-                        );
+                    memberCongestionRepository.findFirstByMemberPlaceIdAndExpiresAtAfterOrderByCreatedAtDesc(
+                        placeId, now
+                    );
 
                 if (optionalMemberCongestion.isEmpty())
                     continue;
@@ -162,26 +219,98 @@ public class MemberPlaceService {
                 MemberCongestion memberCongestion = optionalMemberCongestion.get();
 
                 double distanceMeters = GeoDistance.haversineMeters(
-                        memberLatitude,
-                        memberLongitude,
-                        memberPlace.getLatitude(),
-                        memberPlace.getLongitude()
+                    memberLatitude,
+                    memberLongitude,
+                    memberPlace.getLatitude(),
+                    memberPlace.getLongitude()
                 );
 
+                boolean isFavorite = isFavorite(memberId, memberPlace.getId());
+
                 nodes.add(
-                        ViewportPlaceNodeResponse.of(
-                                memberPlace.getId(),
-                                memberPlace.getName(),
-                                new Coordinate(memberPlace.getLatitude(), memberPlace.getLongitude()),
-                                distanceMeters,
-                                memberCongestion.getCongestionLevel().getName(),
-                                memberCongestion.getCongestionMessage()
-                        )
+                    ViewportPlaceNodeResponse.of(
+                        memberPlace.getId(),
+                        memberPlace.getName(),
+                        new Coordinate(memberPlace.getLatitude(), memberPlace.getLongitude()),
+                        distanceMeters,
+                        memberCongestion.getCongestionLevel().getName(),
+                        memberCongestion.getCongestionMessage(),
+                        isFavorite
+                    )
                 );
+
             }
         }
 
         return nodes;
+    }
+
+    private int sanitizeSize(
+        Integer size
+    ) {
+        if (size == null || size <= 0) {
+            return 10;
+        }
+        return Math.min(size, 100);
+    }
+
+    private Long computeNextCursor(
+        List<MemberCongestionItemResponse> memberCongestionItems
+    ) {
+        if (memberCongestionItems == null || memberCongestionItems.isEmpty()) {
+            return null;
+        }
+
+        int size = memberCongestionItems.size();
+
+        return memberCongestionItems.get(size - 1).memberCongestionId();
+    }
+
+    private boolean isFavorite(
+        String memberId,
+        Long memberPlaceId
+    ) {
+        if (memberId == null) {
+            return false;
+        }
+
+        return favoriteRepository.existsByMemberIdAndMemberPlaceId(
+            memberId,
+            memberPlaceId
+        );
+    }
+
+    private Slice<MemberCongestion> loadMemberCongestionSlice(
+        Long memberPlaceId,
+        Long cursor,
+        Pageable pageable
+    ) {
+        if (cursor == null) {
+            return loadInitialSlice(memberPlaceId, pageable);
+        }
+        return loadNextSlice(memberPlaceId, cursor, pageable);
+    }
+
+    private Slice<MemberCongestion> loadInitialSlice(
+        Long memberPlaceId,
+        Pageable pageable
+    ) {
+        return memberCongestionRepository.findByMemberPlaceIdOrderByIdDesc(
+            memberPlaceId,
+            pageable
+        );
+    }
+
+    private Slice<MemberCongestion> loadNextSlice(
+        Long memberPlaceId,
+        Long cursor,
+        Pageable pageable
+    ) {
+        return memberCongestionRepository.findByMemberPlaceIdAndIdLessThanOrderByIdDesc(
+            memberPlaceId,
+            cursor,
+            pageable
+        );
     }
 
 }

--- a/src/main/java/boombimapi/domain/place/dto/request/ResolveMemberPlaceRequest.java
+++ b/src/main/java/boombimapi/domain/place/dto/request/ResolveMemberPlaceRequest.java
@@ -1,21 +1,29 @@
 package boombimapi.domain.place.dto.request;
 
 public record ResolveMemberPlaceRequest(
-        String uuid,
-        String name,
-        Double latitude,
-        Double longitude,
-
-        String imageUrl
+    String uuid,
+    String name,
+    String address,
+    Double latitude,
+    Double longitude,
+    String imageUrl
 ) {
 
     public static ResolveMemberPlaceRequest of(
-            String uuid,
-            String name,
-            Double latitude,
-            Double longitude,
-            String imageUrl
-            ) {
-        return new ResolveMemberPlaceRequest(uuid, name, latitude, longitude, imageUrl);
+        String uuid,
+        String name,
+        String address,
+        Double latitude,
+        Double longitude,
+        String imageUrl
+    ) {
+        return new ResolveMemberPlaceRequest(
+            uuid,
+            name,
+            address,
+            latitude,
+            longitude,
+            imageUrl
+        );
     }
 }

--- a/src/main/java/boombimapi/domain/place/dto/response/member/GetMemberPlaceDetailResponse.java
+++ b/src/main/java/boombimapi/domain/place/dto/response/member/GetMemberPlaceDetailResponse.java
@@ -1,5 +1,30 @@
 package boombimapi.domain.place.dto.response.member;
 
-public record GetMemberPlaceDetailResponse() {
+import boombimapi.domain.congestion.dto.response.MemberCongestionItemResponse;
+import java.util.List;
+
+public record GetMemberPlaceDetailResponse(
+    MemberPlaceSummaryResponse memberPlaceSummary,
+    List<MemberCongestionItemResponse> memberCongestionItems,
+    boolean hasNext,
+    Long nextCursor,
+    int size
+) {
+
+    public static GetMemberPlaceDetailResponse of(
+        MemberPlaceSummaryResponse memberPlaceSummary,
+        List<MemberCongestionItemResponse> memberCongestionItems,
+        boolean hasNext,
+        Long nextCursor,
+        int size
+    ) {
+        return new GetMemberPlaceDetailResponse(
+            memberPlaceSummary,
+            memberCongestionItems,
+            hasNext,
+            nextCursor,
+            size
+        );
+    }
 
 }

--- a/src/main/java/boombimapi/domain/place/dto/response/member/GetMemberPlaceDetailResponse.java
+++ b/src/main/java/boombimapi/domain/place/dto/response/member/GetMemberPlaceDetailResponse.java
@@ -1,0 +1,5 @@
+package boombimapi.domain.place.dto.response.member;
+
+public record GetMemberPlaceDetailResponse() {
+
+}

--- a/src/main/java/boombimapi/domain/place/dto/response/member/MemberPlaceSummaryResponse.java
+++ b/src/main/java/boombimapi/domain/place/dto/response/member/MemberPlaceSummaryResponse.java
@@ -1,5 +1,32 @@
 package boombimapi.domain.place.dto.response.member;
 
-public record MemberPlaceSummaryResponse() {
+public record MemberPlaceSummaryResponse(
+    Long memberPlaceId,
+    String name,
+    String address,
+    Double latitude,
+    Double longitude,
+    String imageUrl,
+    boolean isFavorite
+) {
 
+    public static MemberPlaceSummaryResponse of(
+        Long memberPlaceId,
+        String name,
+        String address,
+        Double latitude,
+        Double longitude,
+        String imageUrl,
+        boolean isFavorite
+    ) {
+        return new MemberPlaceSummaryResponse(
+            memberPlaceId,
+            name,
+            address,
+            latitude,
+            longitude,
+            imageUrl,
+            isFavorite
+        );
+    }
 }

--- a/src/main/java/boombimapi/domain/place/dto/response/member/MemberPlaceSummaryResponse.java
+++ b/src/main/java/boombimapi/domain/place/dto/response/member/MemberPlaceSummaryResponse.java
@@ -1,0 +1,5 @@
+package boombimapi.domain.place.dto.response.member;
+
+public record MemberPlaceSummaryResponse() {
+
+}

--- a/src/main/java/boombimapi/domain/place/dto/response/member/ResolveMemberPlaceResponse.java
+++ b/src/main/java/boombimapi/domain/place/dto/response/member/ResolveMemberPlaceResponse.java
@@ -1,4 +1,4 @@
-package boombimapi.domain.place.dto.response;
+package boombimapi.domain.place.dto.response.member;
 
 import boombimapi.domain.place.entity.MemberPlace;
 

--- a/src/main/java/boombimapi/domain/place/dto/response/node/ViewportPlaceNodeResponse.java
+++ b/src/main/java/boombimapi/domain/place/dto/response/node/ViewportPlaceNodeResponse.java
@@ -10,7 +10,8 @@ public record ViewportPlaceNodeResponse(
     Coordinate coordinate,
     Double distance,
     String congestionLevelName,
-    String congestionMessage
+    String congestionMessage,
+    boolean isFavorite
 ) implements ViewportNodeResponse {
 
     public static ViewportPlaceNodeResponse of(
@@ -19,7 +20,8 @@ public record ViewportPlaceNodeResponse(
         Coordinate coordinate,
         Double distance,
         String congestionLevelName,
-        String congestionMessage
+        String congestionMessage,
+        boolean isFavorite
     ) {
         return new ViewportPlaceNodeResponse(
             MarkerType.PLACE,
@@ -28,7 +30,8 @@ public record ViewportPlaceNodeResponse(
             coordinate,
             distance,
             congestionLevelName,
-            congestionMessage
+            congestionMessage,
+            isFavorite
         );
     }
 

--- a/src/main/java/boombimapi/domain/place/entity/MemberPlace.java
+++ b/src/main/java/boombimapi/domain/place/entity/MemberPlace.java
@@ -35,6 +35,9 @@ public class MemberPlace extends BaseEntity {
     @Column(name = "name", length = 32, nullable = false)
     private String name;
 
+    @Column(name = "address", length = 32, nullable = false)
+    private String address;
+
     @Column(name = "latitude", nullable = false)
     private Double latitude;
 
@@ -48,12 +51,14 @@ public class MemberPlace extends BaseEntity {
     private MemberPlace(
         String uuid,
         String name,
+        String address,
         Double latitude,
         Double longitude,
         String imageUrl
     ) {
         this.uuid = uuid;
         this.name = name;
+        this.address = address;
         this.latitude = latitude;
         this.longitude = longitude;
         this.imageUrl = imageUrl;
@@ -62,6 +67,7 @@ public class MemberPlace extends BaseEntity {
     public static MemberPlace of(
         String uuid,
         String name,
+        String address,
         Double latitude,
         Double longitude,
         String imageUrl
@@ -69,6 +75,7 @@ public class MemberPlace extends BaseEntity {
         return MemberPlace.builder()
             .uuid(uuid)
             .name(name)
+            .address(address)
             .latitude(latitude)
             .longitude(longitude)
             .imageUrl(imageUrl)

--- a/src/main/java/boombimapi/domain/vote/application/service/impl/VoteServiceImpl.java
+++ b/src/main/java/boombimapi/domain/vote/application/service/impl/VoteServiceImpl.java
@@ -8,7 +8,7 @@ import boombimapi.domain.member.domain.entity.Member;
 import boombimapi.domain.member.domain.repository.MemberRepository;
 import boombimapi.domain.place.application.MemberPlaceService;
 import boombimapi.domain.place.dto.request.ResolveMemberPlaceRequest;
-import boombimapi.domain.place.dto.response.ResolveMemberPlaceResponse;
+import boombimapi.domain.place.dto.response.member.ResolveMemberPlaceResponse;
 import boombimapi.domain.place.entity.MemberPlace;
 import boombimapi.domain.place.repository.MemberPlaceRepository;
 import boombimapi.domain.vote.application.service.VoteService;

--- a/src/main/java/boombimapi/domain/vote/presentation/dto/req/VoteRegisterReq.java
+++ b/src/main/java/boombimapi/domain/vote/presentation/dto/req/VoteRegisterReq.java
@@ -5,22 +5,26 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "투표 생성 요청 DTO")
 public record VoteRegisterReq(
 
-        @Schema(description = "장소 ID", example = "POS12345")
-        String posId,
+    @Schema(description = "장소 ID", example = "POS12345")
+    String posId,
 
-        @Schema(description = "장소 위도", example = "37.5665")
-        double posLatitude,
+    @Schema(description = "장소 위도", example = "37.5665")
+    double posLatitude,
 
-        @Schema(description = "장소 경도", example = "126.9780")
-        double posLongitude,
+    @Schema(description = "장소 경도", example = "126.9780")
+    double posLongitude,
 
-        @Schema(description = "사용자 현재 위도", example = "37.5651")
-        double userLatitude,
+    @Schema(description = "사용자 현재 위도", example = "37.5651")
+    double userLatitude,
 
-        @Schema(description = "사용자 현재 경도", example = "126.9779")
-        double userLongitude,
+    @Schema(description = "사용자 현재 경도", example = "126.9779")
+    double userLongitude,
 
-        @Schema(description = "장소 이름", example = "서울역")
-        String posName
+    @Schema(description = "장소 이름", example = "서울역")
+    String posName,
+
+    @Schema(description = "장소 주소", example = "서울 중구 한강대로 405")
+    String address
 ) {
+
 }

--- a/src/main/java/boombimapi/global/response/ResponseMessage.java
+++ b/src/main/java/boombimapi/global/response/ResponseMessage.java
@@ -15,6 +15,7 @@ public enum ResponseMessage {
     // member place
     GET_MEMBER_PLACES_IN_VIEWPORT_SUCCESS("뷰포트 내 사용자 장소 조회 성공"),
     RESOLVE_MEMBER_PLACE_SUCCESS("사용자 장소 ID 조회 성공"),
+    GET_MEMBER_PLACE_DETAIL_SUCCESS("사용자 장소 상세 조회 성공"),
 
     // member congestion
     CREATE_MEMBER_CONGESTION_SUCCESS("사용자 혼잡도 생성 성공"),

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         default_schema: root        # 기본 스키마


### PR DESCRIPTION
## #️⃣연관된 이슈

- #62 

## 📝작업 내용

- 사용자 장소 상세 조회 API 엔드포인트 생성
- MemberPlaceService에 상세 조회 로직 추가
- 해당 장소에 작성된 모든 MemberCongestion 데이터 조회 가능
- 무한 스크롤 구현 (앱 단에서는 추후 도입)
- Swagger 문서에 API 명세 추가