### PR TITLE
Feat#61 검색 API 만들기 

### DIFF
--- a/src/main/java/boombimapi/domain/congestion/repository/MemberCongestionRepository.java
+++ b/src/main/java/boombimapi/domain/congestion/repository/MemberCongestionRepository.java
@@ -2,9 +2,12 @@ package boombimapi.domain.congestion.repository;
 
 import boombimapi.domain.congestion.entity.MemberCongestion;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+import boombimapi.domain.place.entity.MemberPlace;
 import feign.Param;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -21,11 +24,22 @@ public interface MemberCongestionRepository extends JpaRepository<MemberCongesti
     );
 
     @Query("""
-           SELECT COUNT(mc) 
+           SELECT COUNT(mc)\s
            FROM MemberCongestion mc
            WHERE mc.memberPlace.id = :placeId
              AND CAST(mc.createdAt AS DATE) = CURRENT_DATE
            """)
     long countTodayByPlace(@Param("placeId") Long placeId);
+
+
+    @Query("""
+    select mc
+    from MemberCongestion mc
+    join fetch mc.congestionLevel cl
+    where mc.memberPlace = :place
+    order by mc.createdAt desc
+    """)
+    List<MemberCongestion> findLatestByPlaceFetchLevel(@Param("place") MemberPlace place, Pageable pageable);
+
 
 }

--- a/src/main/java/boombimapi/domain/congestion/repository/MemberCongestionRepository.java
+++ b/src/main/java/boombimapi/domain/congestion/repository/MemberCongestionRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 import boombimapi.domain.place.entity.MemberPlace;
-import feign.Param;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -32,14 +32,7 @@ public interface MemberCongestionRepository extends JpaRepository<MemberCongesti
     long countTodayByPlace(@Param("placeId") Long placeId);
 
 
-    @Query("""
-    select mc
-    from MemberCongestion mc
-    join fetch mc.congestionLevel cl
-    where mc.memberPlace = :place
-    order by mc.createdAt desc
-    """)
-    List<MemberCongestion> findLatestByPlaceFetchLevel(@Param("place") MemberPlace place, Pageable pageable);
+    Optional<MemberCongestion> findTop1ByMemberPlaceIdOrderByCreatedAtDesc(Long placeId);
 
 
 }

--- a/src/main/java/boombimapi/domain/congestion/repository/OfficialCongestionRepository.java
+++ b/src/main/java/boombimapi/domain/congestion/repository/OfficialCongestionRepository.java
@@ -1,8 +1,15 @@
 package boombimapi.domain.congestion.repository;
 
 import boombimapi.domain.congestion.entity.OfficialCongestion;
+
+import java.util.List;
 import java.util.Optional;
+
+import boombimapi.domain.place.entity.OfficialPlace;
+import feign.Param;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface OfficialCongestionRepository extends JpaRepository<OfficialCongestion, Long> {
 
@@ -10,5 +17,15 @@ public interface OfficialCongestionRepository extends JpaRepository<OfficialCong
     Optional<OfficialCongestion> findTopByOfficialPlaceIdOrderByObservedAtDesc(
         Long officialPlaceId
     );
+
+
+    @Query("""
+        select oc
+        from OfficialCongestion oc
+        join fetch oc.congestionLevel cl
+        where oc.officialPlace = :place
+        order by oc.observedAt desc
+        """)
+    List<OfficialCongestion> findLatestByPlaceFetchLevel(@Param("place") OfficialPlace place, Pageable pageable);
 
 }

--- a/src/main/java/boombimapi/domain/congestion/repository/OfficialCongestionRepository.java
+++ b/src/main/java/boombimapi/domain/congestion/repository/OfficialCongestionRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 import boombimapi.domain.place.entity.OfficialPlace;
-import feign.Param;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -19,13 +19,7 @@ public interface OfficialCongestionRepository extends JpaRepository<OfficialCong
     );
 
 
-    @Query("""
-        select oc
-        from OfficialCongestion oc
-        join fetch oc.congestionLevel cl
-        where oc.officialPlace = :place
-        order by oc.observedAt desc
-        """)
-    List<OfficialCongestion> findLatestByPlaceFetchLevel(@Param("place") OfficialPlace place, Pageable pageable);
+
+
 
 }

--- a/src/main/java/boombimapi/domain/member/domain/entity/Member.java
+++ b/src/main/java/boombimapi/domain/member/domain/entity/Member.java
@@ -5,6 +5,7 @@ import boombimapi.domain.alarm.domain.entity.alarm.AlarmRecipient;
 import boombimapi.domain.alarm.domain.entity.fcm.FcmToken;
 import boombimapi.domain.congestion.entity.MemberCongestion;
 import boombimapi.domain.oauth2.domain.entity.SocialProvider;
+import boombimapi.domain.search.domain.entity.Search;
 import boombimapi.domain.vote.domain.entity.Vote;
 import boombimapi.domain.vote.domain.entity.VoteAnswer;
 import boombimapi.domain.vote.domain.entity.VoteDuplication;
@@ -54,8 +55,13 @@ public class Member {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<VoteAnswer> voteAnswers = new ArrayList<>();
 
+    // 7) 혼잡도 멤버들
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberCongestion> memberCongestions = new ArrayList<>();
+
+    // 7) 혼잡도 멤버들
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Search> searchs = new ArrayList<>();
 
     @Column(nullable = false)
     private String email;

--- a/src/main/java/boombimapi/domain/member/domain/entity/Member.java
+++ b/src/main/java/boombimapi/domain/member/domain/entity/Member.java
@@ -86,12 +86,12 @@ public class Member {
     private boolean alarmFlag;
 
     // 첫 로그인일시에는 false 이후에는 계속 true
-    @Column(name= "name_flag", nullable = false)
+    @Column(name = "name_flag", nullable = false)
     private boolean nameFlag;
 
     @Builder
     public Member(String id, String email, String name, String profile,
-                SocialProvider socialProvider, Role role) {
+                  SocialProvider socialProvider, Role role) {
         this.id = id;
         this.email = email;
         this.name = name;
@@ -107,20 +107,27 @@ public class Member {
     }
 
     public void updateName(String name) {
-        this.name=name;
+        this.name = name;
     }
 
-    public void updateProfile(String profile){this.profile= profile;}
+    public void updateProfile(String profile) {
+        this.profile = profile;
+    }
 
     public void updateIsActivateNameFlag() {
-        this.nameFlag=true;
+        this.nameFlag = true;
     }
 
     public void updateIsActivateAlarmFlag() {
-        this.alarmFlag=true;
+        this.alarmFlag = true;
     }
+
     public void updateIsDeactivateAlarmFlag() {
-        this.alarmFlag=false;
+        this.alarmFlag = false;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 
     @PrePersist

--- a/src/main/java/boombimapi/domain/member/presentation/controller/AdminController.java
+++ b/src/main/java/boombimapi/domain/member/presentation/controller/AdminController.java
@@ -1,7 +1,11 @@
 package boombimapi.domain.member.presentation.controller;
 
 import boombimapi.domain.member.application.service.AdminService;
+import boombimapi.domain.member.domain.entity.Member;
+import boombimapi.domain.member.domain.entity.Role;
+import boombimapi.domain.member.domain.repository.MemberRepository;
 import boombimapi.domain.member.presentation.dto.admin.req.AdminLoginReq;
+import boombimapi.domain.oauth2.domain.entity.SocialProvider;
 import boombimapi.domain.oauth2.presentation.dto.res.LoginToken;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -11,7 +15,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
 
 @RestController
 @RequestMapping("/api/admin")
@@ -21,8 +29,10 @@ import org.springframework.web.bind.annotation.*;
 public class AdminController {
 
     private final AdminService adminService;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    @Operation(summary = "[관리자 전용] 일반 로그인", description = "이메일과 비밀번호로 관리자 로그인을 처리합니다.")
+    @Operation(summary = "관리자 일반 로그인", description = "이메일과 비밀번호로 관리자 로그인을 처리합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
             @ApiResponse(responseCode = "401", description = "인증 실패 (이메일 또는 비밀번호 불일치)"),
@@ -32,5 +42,24 @@ public class AdminController {
     public ResponseEntity<LoginToken> adminLogin(@Valid @RequestBody AdminLoginReq req) {
         LoginToken loginToken = adminService.postLogin(req);
         return ResponseEntity.ok(loginToken);
+    }
+
+
+    @PostMapping("/join")
+    public void adminJoin(@Valid @RequestBody AdminLoginReq req) {
+        Member admin = Member.builder()
+                .id(UUID.randomUUID().toString())
+                .email(req.loginId())
+                .name("관리자") // 기본 이름
+                .profile(null)
+                .socialProvider(SocialProvider.KAKAO) // 고정
+                .role(Role.ADMIN)                     // 관리자 권한
+                .build();
+
+        // 비밀번호 encode 해서 세팅
+        admin.setPassword(passwordEncoder.encode(req.password()));
+
+        // 저장
+        memberRepository.save(admin);
     }
 }

--- a/src/main/java/boombimapi/domain/place/repository/MemberPlaceRepository.java
+++ b/src/main/java/boombimapi/domain/place/repository/MemberPlaceRepository.java
@@ -5,9 +5,11 @@ import java.util.List;
 import java.util.Optional;
 
 import boombimapi.domain.search.presentation.dto.PlaceNameProjection;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberPlaceRepository extends JpaRepository<MemberPlace, Long> {
 
@@ -21,7 +23,15 @@ public interface MemberPlaceRepository extends JpaRepository<MemberPlace, Long> 
     );
 
     // 연관 검색
-    List<PlaceNameProjection> findByNameContainingIgnoreCase(String keyword, Pageable pageable);
+    @Query("""
+    select p.name as name
+    from MemberPlace p
+    where lower(p.name) like lower(concat('%', ?1, '%'))
+    order by lower(p.name) asc
+""")
+    List<PlaceNameProjection> searchByName(String keyword, Pageable pageable);
+
+
 
     // 검색 결과
     List<MemberPlace> findEntitiesByNameContainingIgnoreCase(String keyword, Pageable pageable);

--- a/src/main/java/boombimapi/domain/place/repository/MemberPlaceRepository.java
+++ b/src/main/java/boombimapi/domain/place/repository/MemberPlaceRepository.java
@@ -3,6 +3,10 @@ package boombimapi.domain.place.repository;
 import boombimapi.domain.place.entity.MemberPlace;
 import java.util.List;
 import java.util.Optional;
+
+import boombimapi.domain.search.presentation.dto.PlaceNameProjection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberPlaceRepository extends JpaRepository<MemberPlace, Long> {
@@ -15,4 +19,13 @@ public interface MemberPlaceRepository extends JpaRepository<MemberPlace, Long> 
         double minLongitude,
         double maxLongitude
     );
+
+    // 연관 검색
+    List<PlaceNameProjection> findByNameContainingIgnoreCase(String keyword, Pageable pageable);
+
+    // 검색 결과
+    List<MemberPlace> findEntitiesByNameContainingIgnoreCase(String keyword, Pageable pageable);
+
+
+
 }

--- a/src/main/java/boombimapi/domain/place/repository/OfficialPlaceRepository.java
+++ b/src/main/java/boombimapi/domain/place/repository/OfficialPlaceRepository.java
@@ -2,6 +2,9 @@ package boombimapi.domain.place.repository;
 
 import boombimapi.domain.place.entity.OfficialPlace;
 import java.util.List;
+
+import boombimapi.domain.search.presentation.dto.PlaceNameProjection;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OfficialPlaceRepository extends JpaRepository<OfficialPlace, Long> {
@@ -14,4 +17,9 @@ public interface OfficialPlaceRepository extends JpaRepository<OfficialPlace, Lo
         double maxLongitude
     );
 
+    // 연관 검색
+    List<PlaceNameProjection> findByNameContainingIgnoreCase(String keyword, Pageable pageable);
+
+    // 검색 결과
+    List<OfficialPlace> findEntitiesByNameContainingIgnoreCase(String keyword, Pageable pageable);
 }

--- a/src/main/java/boombimapi/domain/place/repository/OfficialPlaceRepository.java
+++ b/src/main/java/boombimapi/domain/place/repository/OfficialPlaceRepository.java
@@ -4,8 +4,10 @@ import boombimapi.domain.place.entity.OfficialPlace;
 import java.util.List;
 
 import boombimapi.domain.search.presentation.dto.PlaceNameProjection;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface OfficialPlaceRepository extends JpaRepository<OfficialPlace, Long> {
 
@@ -18,7 +20,13 @@ public interface OfficialPlaceRepository extends JpaRepository<OfficialPlace, Lo
     );
 
     // 연관 검색
-    List<PlaceNameProjection> findByNameContainingIgnoreCase(String keyword, Pageable pageable);
+    @Query("""
+    select o.name as name
+    from OfficialPlace o
+    where lower(o.name) like lower(concat('%', ?1, '%'))
+    order by lower(o.name) asc
+""")
+    List<PlaceNameProjection> searchByName(String keyword, Pageable pageable);
 
     // 검색 결과
     List<OfficialPlace> findEntitiesByNameContainingIgnoreCase(String keyword, Pageable pageable);

--- a/src/main/java/boombimapi/domain/search/application/SearchService.java
+++ b/src/main/java/boombimapi/domain/search/application/SearchService.java
@@ -17,4 +17,10 @@ public interface SearchService {
 
     // 검색 결과 조회 및 검색 내역 저장
     List<SearchRes> getSearch(String posName, String userId);
+
+    // 개인 삭제
+    void deletePersonal(Long searchId, String userId);
+
+    // 전체 삭제
+    void deleteAll(String userId);
 }

--- a/src/main/java/boombimapi/domain/search/application/SearchService.java
+++ b/src/main/java/boombimapi/domain/search/application/SearchService.java
@@ -16,5 +16,5 @@ public interface SearchService {
 
 
     // 검색 결과 조회 및 검색 내역 저장
-    List<SearchRes> getSearch(String posName);
+    List<SearchRes> getSearch(String posName, String userId);
 }

--- a/src/main/java/boombimapi/domain/search/application/SearchService.java
+++ b/src/main/java/boombimapi/domain/search/application/SearchService.java
@@ -1,4 +1,20 @@
 package boombimapi.domain.search.application;
 
+import boombimapi.domain.search.presentation.dto.res.SearchHistoryRes;
+import boombimapi.domain.search.presentation.dto.res.SearchRelatedRes;
+import boombimapi.domain.search.presentation.dto.res.SearchRes;
+
+import java.util.List;
+
 public interface SearchService {
+
+    // 최근 검색 내역 10개 조회
+    List<SearchHistoryRes> getSearchHistory(String userId);
+
+    // 연관 검색어 조회
+    List<SearchRelatedRes> getSearchRelated(String posName);
+
+
+    // 검색 결과 조회 및 검색 내역 저장
+    List<SearchRes> getSearch(String posName);
 }

--- a/src/main/java/boombimapi/domain/search/application/SearchService.java
+++ b/src/main/java/boombimapi/domain/search/application/SearchService.java
@@ -1,0 +1,4 @@
+package boombimapi.domain.search.application;
+
+public interface SearchService {
+}

--- a/src/main/java/boombimapi/domain/search/application/impl/SearchServiceImpl.java
+++ b/src/main/java/boombimapi/domain/search/application/impl/SearchServiceImpl.java
@@ -1,4 +1,37 @@
 package boombimapi.domain.search.application.impl;
 
-public class SearchServiceImpl {
+import boombimapi.domain.search.application.SearchService;
+import boombimapi.domain.search.domain.repository.SearchRepository;
+import boombimapi.domain.search.presentation.dto.res.SearchHistoryRes;
+import boombimapi.domain.search.presentation.dto.res.SearchRelatedRes;
+import boombimapi.domain.search.presentation.dto.res.SearchRes;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class SearchServiceImpl implements SearchService {
+
+    private final SearchRepository searchRepository;
+
+    @Override
+    public List<SearchHistoryRes> getSearchHistory(String userId) {
+        return null;
+    }
+
+    @Override
+    public List<SearchRelatedRes> getSearchRelated(String posName) {
+        return null;
+    }
+
+    @Override
+    public List<SearchRes> getSearch(String posName) {
+        return null;
+    }
 }

--- a/src/main/java/boombimapi/domain/search/application/impl/SearchServiceImpl.java
+++ b/src/main/java/boombimapi/domain/search/application/impl/SearchServiceImpl.java
@@ -1,14 +1,34 @@
 package boombimapi.domain.search.application.impl;
 
+import boombimapi.domain.congestion.entity.MemberCongestion;
+import boombimapi.domain.congestion.entity.OfficialCongestion;
+import boombimapi.domain.congestion.repository.MemberCongestionRepository;
+import boombimapi.domain.congestion.repository.OfficialCongestionRepository;
+import boombimapi.domain.member.domain.entity.Member;
+import boombimapi.domain.member.domain.repository.MemberRepository;
+import boombimapi.domain.place.entity.MemberPlace;
+import boombimapi.domain.place.entity.OfficialPlace;
+import boombimapi.domain.place.repository.MemberPlaceRepository;
+import boombimapi.domain.place.repository.OfficialPlaceRepository;
 import boombimapi.domain.search.application.SearchService;
+import boombimapi.domain.search.domain.entity.Search;
 import boombimapi.domain.search.domain.repository.SearchRepository;
+import boombimapi.domain.search.presentation.dto.PlaceNameProjection;
 import boombimapi.domain.search.presentation.dto.res.SearchHistoryRes;
 import boombimapi.domain.search.presentation.dto.res.SearchRelatedRes;
 import boombimapi.domain.search.presentation.dto.res.SearchRes;
+import boombimapi.global.infra.exception.error.BoombimException;
+import boombimapi.global.infra.exception.error.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import java.util.List;
 
@@ -20,18 +40,119 @@ public class SearchServiceImpl implements SearchService {
 
     private final SearchRepository searchRepository;
 
+    private final MemberRepository memberRepository;
+
+    // 장소
+    private final MemberPlaceRepository memberPlaceRepository;
+    private final OfficialPlaceRepository officialPlaceRepository;
+
+    // 혼잡도
+    private final OfficialCongestionRepository officialCongestionRepository;
+    private final MemberCongestionRepository memberCongestionRepository;
+
     @Override
     public List<SearchHistoryRes> getSearchHistory(String userId) {
-        return null;
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new BoombimException(ErrorCode.USER_NOT_EXIST));
+
+        return searchRepository.findByMember(member)
+                .stream()
+                .map(search -> SearchHistoryRes.of(search.getId(), search.getSearchWord()))
+                .toList();
     }
 
     @Override
     public List<SearchRelatedRes> getSearchRelated(String posName) {
-        return null;
+        // 각 소스에서 10개씩만 가져오고, 합쳐서 중복 제거 → 최종 10개
+        Pageable limit10 = PageRequest.of(0, 10);
+
+        List<PlaceNameProjection> fromMember =
+                memberPlaceRepository.findByNameContainingIgnoreCase(posName, limit10);
+
+        List<PlaceNameProjection> fromOfficial =
+                officialPlaceRepository.findByNameContainingIgnoreCase(posName, limit10);
+
+        // 이름 기준으로 중복 제거 (대소문자 무시), 입력 키워드와의 "접두" 우선 정렬 → 그다음 사전식
+        String keyLower = posName.toLowerCase(Locale.ROOT);
+
+        // 주석 설명 상세히 해놓음!
+        return Stream.concat(fromMember.stream(), fromOfficial.stream()) // MemberPlace, OfficialPlace 검색 결과 두 개 합침
+                .map(PlaceNameProjection::getName) // Projection 객체에서 placeName(String)만 추출
+                .filter(Objects::nonNull) // null 값 제거
+                .collect(Collectors.toCollection(LinkedHashSet::new)) // 혹시 모르니 중복 제거(Set) + 순서 유지(LinkedHashSet)
+                .stream() // 다시 스트림으로 변환
+                .sorted((a, b) -> { // 정렬 기준 정의
+                    String la = a.toLowerCase(Locale.ROOT); // a 문자열 소문자 변환 (Locale 영향 없음)
+                    String lb = b.toLowerCase(Locale.ROOT); // b 문자열 소문자 변환
+                    boolean aStarts = la.startsWith(keyLower); // a가 검색 키워드로 시작하는지
+                    boolean bStarts = lb.startsWith(keyLower); // b가 검색 키워드로 시작하는지
+                    if (aStarts && !bStarts) return -1; // a만 키워드로 시작하면 a를 먼저
+                    if (!aStarts && bStarts) return 1;  // b만 키워드로 시작하면 b를 먼저
+                    return la.compareTo(lb); // 둘 다 시작 or 둘 다 아니면 사전순 정렬
+                })
+                .limit(10) // 최대 10개까지만 가져오기
+                .map(SearchRelatedRes::of) // String → DTO(SearchRelatedRes) 변환
+                .toList(); // 최종적으로 List<SearchRelatedRes> 반환
+
     }
 
     @Override
-    public List<SearchRes> getSearch(String posName) {
-        return null;
+    public List<SearchRes> getSearch(String posName, String userId) {
+        saveSearchWord(posName, userId);
+
+        Pageable limit10 = PageRequest.of(0, 10);
+
+        List<MemberPlace> memberPlaceEntities =
+                memberPlaceRepository.findEntitiesByNameContainingIgnoreCase(posName, limit10);
+
+        List<OfficialPlace> officialEntities =
+                officialPlaceRepository.findEntitiesByNameContainingIgnoreCase(posName, limit10);
+
+
+        return sortedCongestion(memberPlaceEntities, officialEntities);
+
+    }
+
+
+    private void saveSearchWord(String posName, String userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new BoombimException(ErrorCode.USER_NOT_EXIST));
+
+        Search search = Search.builder().member(member).searchWord(posName).build();
+        searchRepository.save(search);
+    }
+
+    // 장소마다 혼잡도 조회해서 정보 넘겨줘야됨
+    private List<SearchRes> sortedCongestion(List<MemberPlace> memberPlaceEntities, List<OfficialPlace> officialEntities) {
+        List<SearchRes> result = new ArrayList<>();
+
+        for (MemberPlace memberPlace : memberPlaceEntities) {
+
+            MemberCongestion latestMember =
+                    memberCongestionRepository
+                            .findLatestByPlaceFetchLevel(memberPlace, PageRequest.of(0, 1))
+                            .stream().findFirst().orElse(null);
+
+
+            result.add(SearchRes.of(memberPlace.getId(), memberPlace.getName(), latestMember.getCreatedAt(),
+                    latestMember.getCongestionLevel().getName(), "주소", memberPlace.getImageUrl()));
+
+        }
+
+
+        for (OfficialPlace official : officialEntities) {
+            OfficialCongestion latestOfficial =
+                    officialCongestionRepository
+                            .findLatestByPlaceFetchLevel(official, PageRequest.of(0, 1))
+                            .stream().findFirst().orElse(null);
+
+
+            result.add(SearchRes.of(official.getId(), official.getName(), latestOfficial.getObservedAt(),
+                    latestOfficial.getCongestionLevel().getName(), "주소", official.getImageUrl()));
+        }
+
+        result.sort(Comparator.comparing(SearchRes::timeAt).reversed());
+
+        return result;
     }
 }

--- a/src/main/java/boombimapi/domain/search/application/impl/SearchServiceImpl.java
+++ b/src/main/java/boombimapi/domain/search/application/impl/SearchServiceImpl.java
@@ -1,0 +1,4 @@
+package boombimapi.domain.search.application.impl;
+
+public class SearchServiceImpl {
+}

--- a/src/main/java/boombimapi/domain/search/application/impl/SearchServiceImpl.java
+++ b/src/main/java/boombimapi/domain/search/application/impl/SearchServiceImpl.java
@@ -166,7 +166,7 @@ public class SearchServiceImpl implements SearchService {
 
 
                 result.add(SearchRes.of(memberPlace.getId(), memberPlace.getName(), latestMember.getCreatedAt(),
-                        latestMember.getCongestionLevel().getName(), "주소", memberPlace.getImageUrl()));
+                        latestMember.getCongestionLevel().getName(), memberPlace.getAddress(), memberPlace.getImageUrl()));
             }
         }
 
@@ -176,7 +176,7 @@ public class SearchServiceImpl implements SearchService {
                     officialCongestionRepository.findTopByOfficialPlaceIdOrderByObservedAtDesc(official.getId()).orElse(null);
             if (latestOfficial != null) {
                 result.add(SearchRes.of(official.getId(), official.getName(), latestOfficial.getObservedAt(),
-                        latestOfficial.getCongestionLevel().getName(), "주소", official.getImageUrl()));
+                        latestOfficial.getCongestionLevel().getName(), "", official.getImageUrl()));
             }
         }
 

--- a/src/main/java/boombimapi/domain/search/application/impl/SearchServiceImpl.java
+++ b/src/main/java/boombimapi/domain/search/application/impl/SearchServiceImpl.java
@@ -99,7 +99,7 @@ public class SearchServiceImpl implements SearchService {
 
     @Override
     public List<SearchRes> getSearch(String posName, String userId) {
-        if(!Objects.equals(posName, "")){
+        if (!Objects.equals(posName, "")) {
             saveSearchWord(posName, userId); // 공백은 저장 X
         }
 
@@ -115,6 +115,30 @@ public class SearchServiceImpl implements SearchService {
 
         return sortedCongestion(memberPlaceEntities, officialEntities);
 
+    }
+
+    @Override
+    public void deletePersonal(Long searchId, String userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new BoombimException(ErrorCode.USER_NOT_EXIST));
+
+        Search search = searchRepository.findById(searchId).orElse(null);
+        if (search == null) throw new BoombimException(ErrorCode.SEARCH_NOT_EXISTS);
+
+        if (Objects.equals(search.getMember().getId(), member.getId())) {
+            searchRepository.delete(search); // 이중 체크까지 해주자
+        } else {
+            throw new BoombimException(ErrorCode.SEARCH_NOT_EXISTS);
+        }
+
+    }
+
+    @Override
+    public void deleteAll(String userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new BoombimException(ErrorCode.USER_NOT_EXIST));
+
+        searchRepository.deleteByMember(member);
     }
 
 

--- a/src/main/java/boombimapi/domain/search/application/impl/SearchServiceImpl.java
+++ b/src/main/java/boombimapi/domain/search/application/impl/SearchServiceImpl.java
@@ -166,7 +166,7 @@ public class SearchServiceImpl implements SearchService {
 
 
                 result.add(SearchRes.of(memberPlace.getId(), memberPlace.getName(), latestMember.getCreatedAt(),
-                        latestMember.getCongestionLevel().getName(), memberPlace.getAddress(), memberPlace.getImageUrl()));
+                        latestMember.getCongestionLevel().getName(), memberPlace.getAddress(), memberPlace.getImageUrl(), "사용자"));
             }
         }
 
@@ -176,7 +176,7 @@ public class SearchServiceImpl implements SearchService {
                     officialCongestionRepository.findTopByOfficialPlaceIdOrderByObservedAtDesc(official.getId()).orElse(null);
             if (latestOfficial != null) {
                 result.add(SearchRes.of(official.getId(), official.getName(), latestOfficial.getObservedAt(),
-                        latestOfficial.getCongestionLevel().getName(), "", official.getImageUrl()));
+                        latestOfficial.getCongestionLevel().getName(), "", official.getImageUrl(), "공식"));
             }
         }
 

--- a/src/main/java/boombimapi/domain/search/domain/entity/Search.java
+++ b/src/main/java/boombimapi/domain/search/domain/entity/Search.java
@@ -1,4 +1,34 @@
 package boombimapi.domain.search.domain.entity;
 
+import boombimapi.domain.member.domain.entity.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@DynamicUpdate
+
 public class Search {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private String searchWord;
+
+
+    @Builder
+    public Search(Member member, String searchWord) {
+        this.member = member;
+        this.searchWord = searchWord;
+    }
 }

--- a/src/main/java/boombimapi/domain/search/domain/entity/Search.java
+++ b/src/main/java/boombimapi/domain/search/domain/entity/Search.java
@@ -11,7 +11,6 @@ import org.hibernate.annotations.DynamicUpdate;
 @Entity
 @NoArgsConstructor
 @DynamicUpdate
-
 public class Search {
 
     @Id

--- a/src/main/java/boombimapi/domain/search/domain/entity/Search.java
+++ b/src/main/java/boombimapi/domain/search/domain/entity/Search.java
@@ -1,0 +1,4 @@
+package boombimapi.domain.search.domain.entity;
+
+public class Search {
+}

--- a/src/main/java/boombimapi/domain/search/domain/repository/SearchRepository.java
+++ b/src/main/java/boombimapi/domain/search/domain/repository/SearchRepository.java
@@ -1,4 +1,9 @@
 package boombimapi.domain.search.domain.repository;
 
-public class SearchRepository {
+import boombimapi.domain.search.domain.entity.Search;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SearchRepository extends JpaRepository<Search, Long> {
 }

--- a/src/main/java/boombimapi/domain/search/domain/repository/SearchRepository.java
+++ b/src/main/java/boombimapi/domain/search/domain/repository/SearchRepository.java
@@ -1,9 +1,15 @@
 package boombimapi.domain.search.domain.repository;
 
+import boombimapi.domain.member.domain.entity.Member;
 import boombimapi.domain.search.domain.entity.Search;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SearchRepository extends JpaRepository<Search, Long> {
+
+
+    List<Search> findByMember(Member member);
 }

--- a/src/main/java/boombimapi/domain/search/domain/repository/SearchRepository.java
+++ b/src/main/java/boombimapi/domain/search/domain/repository/SearchRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SearchRepository extends JpaRepository<Search, Long> {
 
 
     List<Search> findByMember(Member member);
+
+    Optional<Search> findBySearchWord(String posName);
 }

--- a/src/main/java/boombimapi/domain/search/domain/repository/SearchRepository.java
+++ b/src/main/java/boombimapi/domain/search/domain/repository/SearchRepository.java
@@ -1,0 +1,4 @@
+package boombimapi.domain.search.domain.repository;
+
+public class SearchRepository {
+}

--- a/src/main/java/boombimapi/domain/search/domain/repository/SearchRepository.java
+++ b/src/main/java/boombimapi/domain/search/domain/repository/SearchRepository.java
@@ -15,4 +15,7 @@ public interface SearchRepository extends JpaRepository<Search, Long> {
     List<Search> findByMember(Member member);
 
     Optional<Search> findBySearchWord(String posName);
+
+    // 특정 멤버가 가진 Search 전부 삭제
+    void deleteByMember(Member member);
 }

--- a/src/main/java/boombimapi/domain/search/presentation/controller/SearchController.java
+++ b/src/main/java/boombimapi/domain/search/presentation/controller/SearchController.java
@@ -7,6 +7,9 @@ import boombimapi.domain.search.presentation.dto.res.SearchRelatedRes;
 import boombimapi.domain.search.presentation.dto.res.SearchRes;
 import boombimapi.global.response.BaseOKResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -23,23 +26,32 @@ import static boombimapi.global.response.ResponseMessage.GET_ALARM_SUCCESS;
 @RequestMapping("/api/search")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "Search", description = "검색 관련 API")
 public class SearchController {
 
     private final SearchService searchService;
-
-    @Operation(description = "검색 내역 조회 10개만")
+    @Operation(summary = "검색 내역 조회", description = "사용자가 입력한 검색 내역 조회합니다. ")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 내역 조회 성공"),
+    })
     @GetMapping("/history")
     public ResponseEntity<List<SearchHistoryRes>> getSearchHistory(@AuthenticationPrincipal String userId) {
         return ResponseEntity.ok(searchService.getSearchHistory(userId));
     }
 
-    @Operation(description = "연관검색어")
+    @Operation(summary = "연관 검색어", description = "연관 검색어가 나옵니다. 최대 20개까지 나옵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "연관 검색어 조회 성공"),
+    })
     @GetMapping("/related")
     public ResponseEntity<List<SearchRelatedRes>> getSearchRelated(@RequestParam String posName) {
         return ResponseEntity.ok(searchService.getSearchRelated(posName));
     }
 
-    @Operation(description = "검색 결과 및 검색 내용 저장")
+    @Operation(summary = "검색 상세 조회", description = "검색 버튼을 누르면 실행되는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 상세 조회 성공"),
+    })
     @GetMapping
     public ResponseEntity<List<SearchRes>> getSearch(
             @RequestParam String posName,
@@ -48,7 +60,11 @@ public class SearchController {
         return ResponseEntity.ok(searchService.getSearch(posName, userId));
     }
 
-    @Operation(description = "개인 삭제")
+    @Operation(summary = "검색 내역 개별 삭제", description = "검색 내역을 개별 삭제를 합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "검색 ID 존재하지가 않음"),
+    })
     @DeleteMapping
     public ResponseEntity<BaseOKResponse<Void>> deletePersonal(
             @AuthenticationPrincipal String userId,
@@ -60,7 +76,10 @@ public class SearchController {
                         DELETE_SEARCH_SUCCESS));
     }
 
-    @Operation(description = "전체 삭제")
+    @Operation(summary = "검색 내역 전체 삭제", description = "검색 내역을 전체를 삭제를 합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 전체 삭제 성공"),
+    })
     @DeleteMapping("/all")
     public ResponseEntity<BaseOKResponse<Void>> deleteAll(@AuthenticationPrincipal String userId) {
 

--- a/src/main/java/boombimapi/domain/search/presentation/controller/SearchController.java
+++ b/src/main/java/boombimapi/domain/search/presentation/controller/SearchController.java
@@ -1,4 +1,48 @@
 package boombimapi.domain.search.presentation.controller;
 
+import boombimapi.domain.search.application.SearchService;
+import boombimapi.domain.search.presentation.dto.res.SearchHistoryRes;
+import boombimapi.domain.search.presentation.dto.res.SearchRelatedRes;
+import boombimapi.domain.search.presentation.dto.res.SearchRes;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/search")
+@RequiredArgsConstructor
+@Slf4j
 public class SearchController {
+
+    private final SearchService searchService;
+
+    @Operation(description = "검색 내역 조회 10개만")
+    @GetMapping("/history")
+    public ResponseEntity<List<SearchHistoryRes>> getSearchHistory(@AuthenticationPrincipal String userId) {
+        return ResponseEntity.ok(searchService.getSearchHistory(userId));
+    }
+
+    @Operation(description = "연관검색어")
+    @GetMapping("/related")
+    public ResponseEntity<List<SearchRelatedRes>> getSearchRelated(@RequestParam String posName) {
+        return ResponseEntity.ok(searchService.getSearchRelated(posName));
+    }
+
+    @Operation(description = "검색 결과 및 검색 내용 저장")
+    @GetMapping
+    public ResponseEntity<List<SearchRes>> getSearch(
+            @RequestParam String posName,
+            @AuthenticationPrincipal String userId) {
+
+        return ResponseEntity.ok(searchService.getSearch(posName, userId));
+    }
+
 }

--- a/src/main/java/boombimapi/domain/search/presentation/controller/SearchController.java
+++ b/src/main/java/boombimapi/domain/search/presentation/controller/SearchController.java
@@ -1,6 +1,7 @@
 package boombimapi.domain.search.presentation.controller;
 
 import boombimapi.domain.search.application.SearchService;
+import boombimapi.domain.search.presentation.dto.req.DeletePersonalReq;
 import boombimapi.domain.search.presentation.dto.res.SearchHistoryRes;
 import boombimapi.domain.search.presentation.dto.res.SearchRelatedRes;
 import boombimapi.domain.search.presentation.dto.res.SearchRes;
@@ -8,11 +9,15 @@ import boombimapi.global.response.BaseOKResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+
+import static boombimapi.global.response.ResponseMessage.DELETE_SEARCH_SUCCESS;
+import static boombimapi.global.response.ResponseMessage.GET_ALARM_SUCCESS;
 
 @RestController
 @RequestMapping("/api/search")
@@ -45,14 +50,25 @@ public class SearchController {
 
     @Operation(description = "개인 삭제")
     @DeleteMapping
-    public ResponseEntity<BaseOKResponse<Void>> deletePersonal(@RequestParam String posName) {
-        return null;
+    public ResponseEntity<BaseOKResponse<Void>> deletePersonal(
+            @AuthenticationPrincipal String userId,
+            @RequestBody DeletePersonalReq req) {
+        searchService.deletePersonal(req.searchId(), userId);
+        return ResponseEntity.ok(
+                BaseOKResponse.of(
+                        HttpStatus.OK,
+                        DELETE_SEARCH_SUCCESS));
     }
 
     @Operation(description = "전체 삭제")
     @DeleteMapping("/all")
-    public ResponseEntity<BaseOKResponse<Void>> deleteAll(@RequestParam String posName) {
-        return null;
+    public ResponseEntity<BaseOKResponse<Void>> deleteAll(@AuthenticationPrincipal String userId) {
+
+        searchService.deleteAll(userId);
+        return ResponseEntity.ok(
+                BaseOKResponse.of(
+                        HttpStatus.OK,
+                        DELETE_SEARCH_SUCCESS));
     }
 
 }

--- a/src/main/java/boombimapi/domain/search/presentation/controller/SearchController.java
+++ b/src/main/java/boombimapi/domain/search/presentation/controller/SearchController.java
@@ -1,0 +1,4 @@
+package boombimapi.domain.search.presentation.controller;
+
+public class SearchController {
+}

--- a/src/main/java/boombimapi/domain/search/presentation/controller/SearchController.java
+++ b/src/main/java/boombimapi/domain/search/presentation/controller/SearchController.java
@@ -4,15 +4,13 @@ import boombimapi.domain.search.application.SearchService;
 import boombimapi.domain.search.presentation.dto.res.SearchHistoryRes;
 import boombimapi.domain.search.presentation.dto.res.SearchRelatedRes;
 import boombimapi.domain.search.presentation.dto.res.SearchRes;
+import boombimapi.global.response.BaseOKResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -43,6 +41,18 @@ public class SearchController {
             @AuthenticationPrincipal String userId) {
 
         return ResponseEntity.ok(searchService.getSearch(posName, userId));
+    }
+
+    @Operation(description = "개인 삭제")
+    @DeleteMapping
+    public ResponseEntity<BaseOKResponse<Void>> deletePersonal(@RequestParam String posName) {
+        return null;
+    }
+
+    @Operation(description = "전체 삭제")
+    @DeleteMapping("/all")
+    public ResponseEntity<BaseOKResponse<Void>> deleteAll(@RequestParam String posName) {
+        return null;
     }
 
 }

--- a/src/main/java/boombimapi/domain/search/presentation/dto/PlaceNameProjection.java
+++ b/src/main/java/boombimapi/domain/search/presentation/dto/PlaceNameProjection.java
@@ -1,0 +1,6 @@
+package boombimapi.domain.search.presentation.dto;
+
+public interface PlaceNameProjection {
+    Long getId();
+    String getName();
+}

--- a/src/main/java/boombimapi/domain/search/presentation/dto/req/DeletePersonalReq.java
+++ b/src/main/java/boombimapi/domain/search/presentation/dto/req/DeletePersonalReq.java
@@ -1,6 +1,11 @@
 package boombimapi.domain.search.presentation.dto.req;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "검색 개별 삭제 DTO")
 public record DeletePersonalReq(
+
+        @Schema(description = "검색 ID")
         Long searchId
 ) {
 }

--- a/src/main/java/boombimapi/domain/search/presentation/dto/req/DeletePersonalReq.java
+++ b/src/main/java/boombimapi/domain/search/presentation/dto/req/DeletePersonalReq.java
@@ -1,0 +1,6 @@
+package boombimapi.domain.search.presentation.dto.req;
+
+public record DeletePersonalReq(
+        Long searchId
+) {
+}

--- a/src/main/java/boombimapi/domain/search/presentation/dto/res/SearchHistoryRes.java
+++ b/src/main/java/boombimapi/domain/search/presentation/dto/res/SearchHistoryRes.java
@@ -1,8 +1,12 @@
 package boombimapi.domain.search.presentation.dto.res;
 
-public record SearchHistoryRes(
-        Long searchId,
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "검색 내역 조회")
+public record SearchHistoryRes(
+        @Schema(description = "검색 ID")
+        Long searchId,
+        @Schema(description = "검색 장소 이름")
         String posName
 ) {
     public static SearchHistoryRes of(Long searchId, String posName){

--- a/src/main/java/boombimapi/domain/search/presentation/dto/res/SearchHistoryRes.java
+++ b/src/main/java/boombimapi/domain/search/presentation/dto/res/SearchHistoryRes.java
@@ -1,0 +1,11 @@
+package boombimapi.domain.search.presentation.dto.res;
+
+public record SearchHistoryRes(
+        Long searchId,
+
+        String posName
+) {
+    public static SearchHistoryRes of(Long searchId, String posName){
+        return new SearchHistoryRes(searchId, posName);
+    }
+}

--- a/src/main/java/boombimapi/domain/search/presentation/dto/res/SearchRelatedRes.java
+++ b/src/main/java/boombimapi/domain/search/presentation/dto/res/SearchRelatedRes.java
@@ -1,6 +1,11 @@
 package boombimapi.domain.search.presentation.dto.res;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "연관 검색어")
 public record SearchRelatedRes(
+
+        @Schema(description = "검색 장소 이름")
         String posName
 ) {
     public static SearchRelatedRes of(String posName){

--- a/src/main/java/boombimapi/domain/search/presentation/dto/res/SearchRelatedRes.java
+++ b/src/main/java/boombimapi/domain/search/presentation/dto/res/SearchRelatedRes.java
@@ -1,0 +1,9 @@
+package boombimapi.domain.search.presentation.dto.res;
+
+public record SearchRelatedRes(
+        String posName
+) {
+    public static SearchRelatedRes of(String posName){
+        return new SearchRelatedRes(posName);
+    }
+}

--- a/src/main/java/boombimapi/domain/search/presentation/dto/res/SearchRes.java
+++ b/src/main/java/boombimapi/domain/search/presentation/dto/res/SearchRes.java
@@ -1,0 +1,30 @@
+package boombimapi.domain.search.presentation.dto.res;
+
+import java.time.LocalDateTime;
+
+import java.time.LocalDateTime;
+
+public record SearchRes(
+        Long placeId,
+        String posName,
+        LocalDateTime timeAt, // 가장 최신 날짜
+        String answerType,
+        String address,
+        String imageUrl
+) {
+    public static SearchRes of(Long id,
+                               String posName,
+                               LocalDateTime timeAt,
+                               String answerType,
+                               String address,
+                               String imageUrl) {
+        return new SearchRes(
+                id,
+                posName,
+                timeAt,
+                answerType,
+                address,
+                imageUrl
+        );
+    }
+}

--- a/src/main/java/boombimapi/domain/search/presentation/dto/res/SearchRes.java
+++ b/src/main/java/boombimapi/domain/search/presentation/dto/res/SearchRes.java
@@ -2,29 +2,44 @@ package boombimapi.domain.search.presentation.dto.res;
 
 import java.time.LocalDateTime;
 
-import java.time.LocalDateTime;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "검색 결과 응답 모델")
 public record SearchRes(
+
+        @Schema(description = "장소 ID", example = "12345")
         Long placeId,
+
+        @Schema(description = "장소명", example = "스타벅스 강남점")
         String posName,
-        LocalDateTime timeAt, // 가장 최신 날짜
+
+        @Schema(description = "가장 최신 날짜 그 몇분전 설명", example = "2024-12-01T14:30:00")
+        LocalDateTime timeAt,
+
+        @Schema(description = "최신 답변 유형", example = "여유", allowableValues = {"여유", "보통", "약간 붐빔", "붐빔"})
         String answerType,
+
+        @Schema(description = "주소", example = "서울특별시 강남구 테헤란로 123")
         String address,
-        String imageUrl
+
+        @Schema(description = "이미지 URL // 원래 공식만 주는게 맞는데 나중을 사용자도 올린거 다 주겠음", example = "https://example.com/image.jpg")
+        String imageUrl,
+
+        @Schema(description = "장소 유형", example = "공식 or 사용자가 올린거")
+        String placeType
+
 ) {
-    public static SearchRes of(Long id,
-                               String posName,
-                               LocalDateTime timeAt,
-                               String answerType,
-                               String address,
-                               String imageUrl) {
+    @Schema(description = "SearchRes 객체 생성을 위한 팩토리 메서드")
+    public static SearchRes of(Long id, String posName, LocalDateTime timeAt,
+                               String answerType, String address, String imageUrl, String placeType) {
         return new SearchRes(
                 id,
                 posName,
                 timeAt,
                 answerType,
                 address,
-                imageUrl
+                imageUrl,
+                placeType
         );
     }
 }

--- a/src/main/java/boombimapi/domain/vote/application/service/impl/VoteServiceImpl.java
+++ b/src/main/java/boombimapi/domain/vote/application/service/impl/VoteServiceImpl.java
@@ -73,7 +73,7 @@ public class VoteServiceImpl implements VoteService {
         if (user == null)
             throw new BoombimException(ErrorCode.USER_NOT_EXIST);
 
-        //위도 경도 100m 맞는지 true면 있음 false면 없음
+        //위도 경도 100m 맞는지 true면 있음 false면 없음 ==> 이제부터 300m로 통일
         boolean result = isWithin300Meters(
             req.posLatitude(), req.posLongitude(),
             req.userLatitude(), req.userLongitude()

--- a/src/main/java/boombimapi/global/infra/exception/error/ErrorCode.java
+++ b/src/main/java/boombimapi/global/infra/exception/error/ErrorCode.java
@@ -80,7 +80,8 @@ public enum ErrorCode {
     CONGESTION_LEVEL_NOT_FOUND(-700, "해당 혼잡도 수준이 존재하지 않습니다.", 406),
 
     // favorite
-    FAVORITE_ALREADY_EXISTS(-800, "이미 즐겨찾기 한 사용자 장소입니다.", 409);
+    FAVORITE_ALREADY_EXISTS(-800, "이미 즐겨찾기 한 사용자 장소입니다.", 409),
+    SEARCH_NOT_EXISTS(-801, "해당 검색 ID가 없습니다.", 409);
 
     private final int code;
     private final String message;

--- a/src/main/java/boombimapi/global/response/ResponseMessage.java
+++ b/src/main/java/boombimapi/global/response/ResponseMessage.java
@@ -35,7 +35,10 @@ public enum ResponseMessage {
     LOGOUT_SUCCESS("로그아웃 성공"),
 
     // alarm
-    GET_ALARM_SUCCESS("알림 성공");
+    GET_ALARM_SUCCESS("알림 성공"),
+
+    // search
+    DELETE_SEARCH_SUCCESS("검색 삭제 성공");
 
 
     private final String message;

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         default_schema: root        # 기본 스키마


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #61 

## 📝작업 내용

> 검색  API(검색 내역조회, 검색 상세 조회, 연관 검색 조회, 검색 개별 삭제, 검색 전체 삭제) 5개 구현했습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?