### PR TITLE
[Fix] 인근 한산한 공식 장소 조회 시 법정동(legalDong) 필드에 값이 누락되는 문제 해결

### DIFF
--- a/src/main/java/boombimapi/domain/place/api/OfficialPlaceController.java
+++ b/src/main/java/boombimapi/domain/place/api/OfficialPlaceController.java
@@ -5,7 +5,7 @@ import static boombimapi.global.response.ResponseMessage.*;
 import boombimapi.domain.place.application.OfficialPlaceService;
 import boombimapi.domain.place.dto.request.ViewportRequest;
 import boombimapi.domain.place.dto.response.official.CongestedOfficialPlaceResponse;
-import boombimapi.domain.place.dto.response.official.NearbyOfficialPlaceResponse;
+import boombimapi.domain.place.dto.response.official.NearbyNonCongestedOfficialPlaceResponse;
 import boombimapi.domain.place.dto.response.official.OfficialPlaceOverviewResponse;
 import boombimapi.domain.place.dto.response.ViewportResponse;
 import boombimapi.global.response.BaseResponse;
@@ -80,7 +80,7 @@ public class OfficialPlaceController {
         @ApiResponse(responseCode = "200", description = "인근 여유 공식 장소 조회 성공")
     })
     @GetMapping("/nearby-non-congested")
-    public ResponseEntity<BaseResponse<List<NearbyOfficialPlaceResponse>>> getNearbyNonCongestedOfficialPlace(
+    public ResponseEntity<BaseResponse<List<NearbyNonCongestedOfficialPlaceResponse>>> getNearbyNonCongestedOfficialPlace(
         @RequestParam double latitude,
         @RequestParam double longitude
     ) {

--- a/src/main/java/boombimapi/domain/place/api/OfficialPlaceController.java
+++ b/src/main/java/boombimapi/domain/place/api/OfficialPlaceController.java
@@ -73,7 +73,7 @@ public class OfficialPlaceController {
     }
 
     @Operation(
-        summary = "인근 공식 장소 TOP 10 (여유/보통)",
+        summary = "인근 한산한 공식 장소 TOP 10",
         description = "사용자 위치 기준으로 혼잡도 수준이 '여유' 또는 '보통'인 공식 장소 10개를 거리순으로 반환합니다."
     )
     @ApiResponses({

--- a/src/main/java/boombimapi/domain/place/application/OfficialPlaceService.java
+++ b/src/main/java/boombimapi/domain/place/application/OfficialPlaceService.java
@@ -12,7 +12,7 @@ import boombimapi.domain.congestion.repository.OfficialPlaceCongestionRankProjec
 import boombimapi.domain.favorite.repository.FavoriteRepository;
 import boombimapi.domain.place.dto.request.ViewportRequest;
 import boombimapi.domain.place.dto.response.official.CongestedOfficialPlaceResponse;
-import boombimapi.domain.place.dto.response.official.NearbyOfficialPlaceResponse;
+import boombimapi.domain.place.dto.response.official.NearbyNonCongestedOfficialPlaceResponse;
 import boombimapi.domain.place.dto.response.official.OfficialPlaceDemographics;
 import boombimapi.domain.place.dto.response.official.OfficialPlaceForecast;
 import boombimapi.domain.place.dto.response.official.OfficialPlaceOverviewResponse;
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -168,7 +167,7 @@ public class OfficialPlaceService {
         );
     }
 
-    public List<NearbyOfficialPlaceResponse> getNearbyNonCongestedOfficialPlace(
+    public List<NearbyNonCongestedOfficialPlaceResponse> getNearbyNonCongestedOfficialPlace(
         double latitude,
         double longitude
     ) {
@@ -177,10 +176,10 @@ public class OfficialPlaceService {
         List<NearbyOfficialPlaceProjection> rows = officialPlaceRepository
             .findNearbyNonCongestedHaversine(latitude, longitude, limit);
 
-        ArrayList<NearbyOfficialPlaceResponse> result = new ArrayList<>(rows.size());
+        ArrayList<NearbyNonCongestedOfficialPlaceResponse> result = new ArrayList<>(rows.size());
 
         for (NearbyOfficialPlaceProjection row : rows) {
-            result.add(NearbyOfficialPlaceResponse.from(row));
+            result.add(NearbyNonCongestedOfficialPlaceResponse.from(row));
         }
 
         return result;

--- a/src/main/java/boombimapi/domain/place/application/OfficialPlaceService.java
+++ b/src/main/java/boombimapi/domain/place/application/OfficialPlaceService.java
@@ -19,7 +19,7 @@ import boombimapi.domain.place.dto.response.official.OfficialPlaceOverviewRespon
 import boombimapi.domain.place.dto.response.ViewportResponse;
 import boombimapi.domain.place.entity.OfficialPlace;
 import boombimapi.domain.place.repository.OfficialPlaceRepository;
-import boombimapi.domain.place.repository.projection.NearbyOfficialPlaceProjection;
+import boombimapi.domain.place.repository.projection.NearbyNonCongestedOfficialPlaceProjection;
 import boombimapi.global.dto.Coordinate;
 import boombimapi.global.infra.exception.error.BoombimException;
 import java.util.ArrayList;
@@ -173,12 +173,12 @@ public class OfficialPlaceService {
     ) {
         int limit = 10;
 
-        List<NearbyOfficialPlaceProjection> rows = officialPlaceRepository
+        List<NearbyNonCongestedOfficialPlaceProjection> rows = officialPlaceRepository
             .findNearbyNonCongestedHaversine(latitude, longitude, limit);
 
         ArrayList<NearbyNonCongestedOfficialPlaceResponse> result = new ArrayList<>(rows.size());
 
-        for (NearbyOfficialPlaceProjection row : rows) {
+        for (NearbyNonCongestedOfficialPlaceProjection row : rows) {
             result.add(NearbyNonCongestedOfficialPlaceResponse.from(row));
         }
 

--- a/src/main/java/boombimapi/domain/place/application/OfficialPlaceService.java
+++ b/src/main/java/boombimapi/domain/place/application/OfficialPlaceService.java
@@ -174,7 +174,7 @@ public class OfficialPlaceService {
         int limit = 10;
 
         List<NearbyNonCongestedOfficialPlaceProjection> rows = officialPlaceRepository
-            .findNearbyNonCongestedHaversine(latitude, longitude, limit);
+            .findNearbyNonCongestedOfficialPlace(latitude, longitude, limit);
 
         ArrayList<NearbyNonCongestedOfficialPlaceResponse> result = new ArrayList<>(rows.size());
 

--- a/src/main/java/boombimapi/domain/place/dto/response/official/NearbyNonCongestedOfficialPlaceResponse.java
+++ b/src/main/java/boombimapi/domain/place/dto/response/official/NearbyNonCongestedOfficialPlaceResponse.java
@@ -1,6 +1,6 @@
 package boombimapi.domain.place.dto.response.official;
 
-import boombimapi.domain.place.repository.projection.NearbyOfficialPlaceProjection;
+import boombimapi.domain.place.repository.projection.NearbyNonCongestedOfficialPlaceProjection;
 import java.time.LocalDateTime;
 
 public record NearbyNonCongestedOfficialPlaceResponse(
@@ -14,7 +14,7 @@ public record NearbyNonCongestedOfficialPlaceResponse(
 ) {
 
     public static NearbyNonCongestedOfficialPlaceResponse from(
-        NearbyOfficialPlaceProjection row
+        NearbyNonCongestedOfficialPlaceProjection row
     ) {
         return new NearbyNonCongestedOfficialPlaceResponse(
             row.getId(),

--- a/src/main/java/boombimapi/domain/place/dto/response/official/NearbyNonCongestedOfficialPlaceResponse.java
+++ b/src/main/java/boombimapi/domain/place/dto/response/official/NearbyNonCongestedOfficialPlaceResponse.java
@@ -3,7 +3,7 @@ package boombimapi.domain.place.dto.response.official;
 import boombimapi.domain.place.repository.projection.NearbyOfficialPlaceProjection;
 import java.time.LocalDateTime;
 
-public record NearbyOfficialPlaceResponse(
+public record NearbyNonCongestedOfficialPlaceResponse(
     Long officialPlaceId,
     String officialPlaceName,
     String legalDong,
@@ -13,10 +13,10 @@ public record NearbyOfficialPlaceResponse(
     double distanceMeters
 ) {
 
-    public static NearbyOfficialPlaceResponse from(
+    public static NearbyNonCongestedOfficialPlaceResponse from(
         NearbyOfficialPlaceProjection row
     ) {
-        return new NearbyOfficialPlaceResponse(
+        return new NearbyNonCongestedOfficialPlaceResponse(
             row.getId(),
             row.getName(),
             row.getLegalDong(),

--- a/src/main/java/boombimapi/domain/place/repository/OfficialPlaceRepository.java
+++ b/src/main/java/boombimapi/domain/place/repository/OfficialPlaceRepository.java
@@ -55,7 +55,8 @@ public interface OfficialPlaceRepository extends JpaRepository<OfficialPlace, Lo
                  POWER(SIN(RADIANS(p.centroid_longitude - :longitude) / 2), 2)
                ))                    AS distanceMeters,
                f.levelName           AS congestionLevelName,
-                f.observed_at AS observedAt
+               f.observed_at         AS observedAt,
+               p.legal_dong          AS legalDong
         FROM official_places p
         JOIN filtered f ON f.official_place_id = p.id
         ORDER BY distanceMeters ASC, f.observed_at DESC, p.id ASC

--- a/src/main/java/boombimapi/domain/place/repository/OfficialPlaceRepository.java
+++ b/src/main/java/boombimapi/domain/place/repository/OfficialPlaceRepository.java
@@ -1,7 +1,7 @@
 package boombimapi.domain.place.repository;
 
 import boombimapi.domain.place.entity.OfficialPlace;
-import boombimapi.domain.place.repository.projection.NearbyOfficialPlaceProjection;
+import boombimapi.domain.place.repository.projection.NearbyNonCongestedOfficialPlaceProjection;
 import java.util.List;
 
 import boombimapi.domain.search.presentation.dto.PlaceNameProjection;
@@ -61,7 +61,7 @@ public interface OfficialPlaceRepository extends JpaRepository<OfficialPlace, Lo
         ORDER BY distanceMeters ASC, f.observed_at DESC, p.id ASC
         LIMIT :limit
         """, nativeQuery = true)
-    List<NearbyOfficialPlaceProjection> findNearbyNonCongestedHaversine(
+    List<NearbyNonCongestedOfficialPlaceProjection> findNearbyNonCongestedHaversine(
         @Param("latitude") double latitude,
         @Param("longitude") double longitude,
         @Param("limit") int limit

--- a/src/main/java/boombimapi/domain/place/repository/OfficialPlaceRepository.java
+++ b/src/main/java/boombimapi/domain/place/repository/OfficialPlaceRepository.java
@@ -61,7 +61,7 @@ public interface OfficialPlaceRepository extends JpaRepository<OfficialPlace, Lo
         ORDER BY distanceMeters ASC, f.observed_at DESC, p.id ASC
         LIMIT :limit
         """, nativeQuery = true)
-    List<NearbyNonCongestedOfficialPlaceProjection> findNearbyNonCongestedHaversine(
+    List<NearbyNonCongestedOfficialPlaceProjection> findNearbyNonCongestedOfficialPlace(
         @Param("latitude") double latitude,
         @Param("longitude") double longitude,
         @Param("limit") int limit

--- a/src/main/java/boombimapi/domain/place/repository/projection/NearbyNonCongestedOfficialPlaceProjection.java
+++ b/src/main/java/boombimapi/domain/place/repository/projection/NearbyNonCongestedOfficialPlaceProjection.java
@@ -2,7 +2,7 @@ package boombimapi.domain.place.repository.projection;
 
 import java.time.LocalDateTime;
 
-public interface NearbyOfficialPlaceProjection {
+public interface NearbyNonCongestedOfficialPlaceProjection {
 
     Long getId();
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #91 

## 📝작업 내용

법정동(`legalDong`)이 누락된 채로 응답이 내려가던 문제 해결