### PR TITLE
[Refactor] Response에 누락된 필드 추가

### DIFF
--- a/src/main/java/boombimapi/domain/congestion/dto/response/MemberCongestionItemResponse.java
+++ b/src/main/java/boombimapi/domain/congestion/dto/response/MemberCongestionItemResponse.java
@@ -1,24 +1,31 @@
 package boombimapi.domain.congestion.dto.response;
 
-import boombimapi.domain.congestion.entity.MemberCongestion;
 import java.time.LocalDateTime;
 
 public record MemberCongestionItemResponse(
     Long memberCongestionId,
+    String memberProfile,
+    String memberName,
     String congestionLevelName,
     String congestionLevelMessage,
     LocalDateTime createdAt
 ) {
 
     public static MemberCongestionItemResponse of(
-        MemberCongestion memberCongestion
+        Long memberCongestionId,
+        String memberProfile,
+        String memberName,
+        String congestionLevelName,
+        String congestionLevelMessage,
+        LocalDateTime createdAt
     ) {
         return new MemberCongestionItemResponse(
-            memberCongestion.getId(),
-            memberCongestion.getCongestionLevel().getName(),
-            memberCongestion.getCongestionMessage(),
-            memberCongestion.getCreatedAt()
+            memberCongestionId,
+            memberProfile,
+            memberName,
+            congestionLevelName,
+            congestionLevelMessage,
+            createdAt
         );
     }
-
 }

--- a/src/main/java/boombimapi/domain/place/dto/response/node/ViewportPlaceNodeResponse.java
+++ b/src/main/java/boombimapi/domain/place/dto/response/node/ViewportPlaceNodeResponse.java
@@ -3,6 +3,7 @@ package boombimapi.domain.place.dto.response.node;
 import boombimapi.domain.place.dto.type.MarkerType;
 import boombimapi.domain.place.entity.PlaceType;
 import boombimapi.global.dto.Coordinate;
+import java.time.LocalDateTime;
 
 public record ViewportPlaceNodeResponse(
     MarkerType type,
@@ -13,6 +14,7 @@ public record ViewportPlaceNodeResponse(
     Double distance,
     String congestionLevelName,
     String congestionMessage,
+    LocalDateTime createdAt,
     boolean isFavorite
 ) implements ViewportNodeResponse {
 
@@ -23,6 +25,7 @@ public record ViewportPlaceNodeResponse(
         Double distance,
         String congestionLevelName,
         String congestionMessage,
+        LocalDateTime createdAt,
         boolean isFavorite
     ) {
         return new ViewportPlaceNodeResponse(
@@ -34,6 +37,7 @@ public record ViewportPlaceNodeResponse(
             distance,
             congestionLevelName,
             congestionMessage,
+            createdAt,
             isFavorite
         );
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #95 

## 📝작업 내용

- `MemberCongestionItemResponse`
  - 사용자 프로필 사진 (`profile`)
  - 사용자 닉네임 (`name`)
- `ViewportPlaceNodeResponse`
  - 최신 혼잡도 생성 시각 (`createdAt`)