### PR TITLE
[Fix] `CustomSecurityLogger`의 중복 등록 제거

### DIFF
--- a/src/main/java/boombimapi/global/config/SecurityConfig.java
+++ b/src/main/java/boombimapi/global/config/SecurityConfig.java
@@ -83,7 +83,6 @@ public class SecurityConfig {
                                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized")
                         ))
 
-                .addFilterBefore(new CustomSecurityLogger(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(new BoombimAuthExceptionFilter(objectMapper), CorsFilter.class)
                 .addFilterAfter(new BoombimJWTFilter(jwtUtil, excludedUrls), UsernamePasswordAuthenticationFilter.class);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #113 

## 📝작업 내용

`SecurityConfig`에서 `CustomSecurityLogger`가 등록되던 부분을 제거하여 서블릿 필터 체인에만 등록되도록 수정