### PR TITLE
[Feat] AI 혼잡도 메시지 생성에 Rate Limit을 위한 Token Bucket 적용

### DIFF
--- a/src/main/java/boombimapi/domain/clova/application/ClovaService.java
+++ b/src/main/java/boombimapi/domain/clova/application/ClovaService.java
@@ -13,6 +13,7 @@ import boombimapi.domain.clova.infrastructure.parser.ClovaParser;
 import boombimapi.domain.clova.infrastructure.repository.AiAttemptTokenRepository;
 import boombimapi.domain.clova.vo.AiAttemptToken;
 import boombimapi.global.infra.exception.error.BoombimException;
+import boombimapi.global.infra.exception.error.RateLimitedException;
 import boombimapi.global.infra.ratelimit.AiAttemptTokenBucketLimiter;
 import boombimapi.global.properties.AiAttemptTokenBucketProperties;
 import boombimapi.global.properties.ClovaGenerationProperties;
@@ -64,7 +65,7 @@ public class ClovaService {
 
         if (!aiAttemptRateLimitDecision.allowed()) {
             long retryAfterSeconds = aiAttemptRateLimitDecision.retryAfterSeconds();
-            throw new BoombimException(AI_ATTEMPT_RATE_LIMITED);
+            throw new RateLimitedException(AI_ATTEMPT_RATE_LIMITED, retryAfterSeconds);
         }
 
         validateAiAttemptToken(memberId, request);

--- a/src/main/java/boombimapi/domain/place/application/MemberPlaceService.java
+++ b/src/main/java/boombimapi/domain/place/application/MemberPlaceService.java
@@ -19,7 +19,7 @@ import boombimapi.domain.place.dto.response.node.ViewportNodeResponse;
 import boombimapi.domain.place.dto.response.node.ViewportPlaceNodeResponse;
 import boombimapi.domain.place.entity.MemberPlace;
 import boombimapi.domain.place.repository.MemberPlaceRepository;
-import boombimapi.global.dto.Coordinate;
+import boombimapi.global.vo.Coordinate;
 import boombimapi.global.geo.core.ClusterMarker;
 import boombimapi.global.geo.core.ClusterPoint;
 import boombimapi.global.geo.core.Clusterer;

--- a/src/main/java/boombimapi/domain/place/application/OfficialPlaceService.java
+++ b/src/main/java/boombimapi/domain/place/application/OfficialPlaceService.java
@@ -20,7 +20,7 @@ import boombimapi.domain.place.dto.response.ViewportResponse;
 import boombimapi.domain.place.entity.OfficialPlace;
 import boombimapi.domain.place.repository.OfficialPlaceRepository;
 import boombimapi.domain.place.repository.projection.NearbyNonCongestedOfficialPlaceProjection;
-import boombimapi.global.dto.Coordinate;
+import boombimapi.global.vo.Coordinate;
 import boombimapi.global.infra.exception.error.BoombimException;
 import java.util.ArrayList;
 import java.util.Comparator;

--- a/src/main/java/boombimapi/domain/place/dto/request/ViewportRequest.java
+++ b/src/main/java/boombimapi/domain/place/dto/request/ViewportRequest.java
@@ -1,6 +1,6 @@
 package boombimapi.domain.place.dto.request;
 
-import boombimapi.global.dto.Coordinate;
+import boombimapi.global.vo.Coordinate;
 
 public record ViewportRequest(
     Coordinate topLeft,

--- a/src/main/java/boombimapi/domain/place/dto/response/ViewportResponse.java
+++ b/src/main/java/boombimapi/domain/place/dto/response/ViewportResponse.java
@@ -1,7 +1,7 @@
 package boombimapi.domain.place.dto.response;
 
 import boombimapi.domain.place.entity.PlaceType;
-import boombimapi.global.dto.Coordinate;
+import boombimapi.global.vo.Coordinate;
 
 public record ViewportResponse(
     Long officialPlaceId,

--- a/src/main/java/boombimapi/domain/place/dto/response/node/ViewportClusterNodeResponse.java
+++ b/src/main/java/boombimapi/domain/place/dto/response/node/ViewportClusterNodeResponse.java
@@ -1,7 +1,7 @@
 package boombimapi.domain.place.dto.response.node;
 
 import boombimapi.domain.place.dto.type.MarkerType;
-import boombimapi.global.dto.Coordinate;
+import boombimapi.global.vo.Coordinate;
 import java.util.Map;
 
 public record ViewportClusterNodeResponse(

--- a/src/main/java/boombimapi/domain/place/dto/response/node/ViewportPlaceNodeResponse.java
+++ b/src/main/java/boombimapi/domain/place/dto/response/node/ViewportPlaceNodeResponse.java
@@ -2,7 +2,7 @@ package boombimapi.domain.place.dto.response.node;
 
 import boombimapi.domain.place.dto.type.MarkerType;
 import boombimapi.domain.place.entity.PlaceType;
-import boombimapi.global.dto.Coordinate;
+import boombimapi.global.vo.Coordinate;
 import java.time.LocalDateTime;
 
 public record ViewportPlaceNodeResponse(

--- a/src/main/java/boombimapi/global/config/RateLimitConfig.java
+++ b/src/main/java/boombimapi/global/config/RateLimitConfig.java
@@ -1,0 +1,5 @@
+package boombimapi.global.config;
+
+public class RateLimitConfig {
+
+}

--- a/src/main/java/boombimapi/global/config/RateLimitConfig.java
+++ b/src/main/java/boombimapi/global/config/RateLimitConfig.java
@@ -1,5 +1,25 @@
 package boombimapi.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.Resource;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.scripting.support.ResourceScriptSource;
+
+@Configuration
 public class RateLimitConfig {
+
+    @Bean
+    public DefaultRedisScript<String> aiAttemptTokenBucketScript(
+        @Value("classpath:lua/ai_attempt_token_bucket.lua") Resource resource
+    ) {
+        DefaultRedisScript<String> script = new DefaultRedisScript<>();
+
+        script.setScriptSource(new ResourceScriptSource(resource));
+        script.setResultType(String.class);
+
+        return script;
+    }
 
 }

--- a/src/main/java/boombimapi/global/infra/exception/GlobalExceptionHandler.java
+++ b/src/main/java/boombimapi/global/infra/exception/GlobalExceptionHandler.java
@@ -3,7 +3,9 @@ package boombimapi.global.infra.exception;
 
 import boombimapi.global.infra.exception.error.BoombimException;
 import boombimapi.global.infra.exception.error.ErrorCode;
-import boombimapi.global.infra.exception.error.ErrorResponse;
+import boombimapi.global.infra.exception.error.response.ErrorResponse;
+import boombimapi.global.infra.exception.error.RateLimitedException;
+import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -21,18 +23,31 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BoombimException.class)
     public ResponseEntity<ErrorResponse> handleFlowException(BoombimException e) {
         log.error("BoombimException caught - ErrorCode: {}, Message: {}",
-                e.getErrorCode(), e.getMessage());
+            e.getErrorCode(), e.getMessage());
         return ResponseEntity
-                .status(e.getHttpStatusCode())
-                .body(ErrorResponse.of(e));
+            .status(e.getHttpStatusCode())
+            .body(ErrorResponse.of(e));
+    }
+
+    @ExceptionHandler(RateLimitedException.class)
+    public ResponseEntity<ErrorResponse> handleRateLimited(
+        RateLimitedException e
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime retryAt = now.plusSeconds(e.getRetryAfterSeconds());
+
+        return ResponseEntity
+            .status(e.getErrorCode().getHttpCode())
+            .body(ErrorResponse.of(e.getErrorCode(), now, retryAt));
+
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleUnexpectedException(Exception e) {
         log.error("Unexpected exception caught: ", e);
         return ResponseEntity
-                .status(500)
-                .body(ErrorResponse.of(ErrorCode.SERVER_UNTRACKED_ERROR));
+            .status(500)
+            .body(ErrorResponse.of(ErrorCode.SERVER_UNTRACKED_ERROR));
     }
 
     // ENUM 클래스 예외 잡을려고 넣었습니다.
@@ -41,13 +56,13 @@ public class GlobalExceptionHandler {
         Throwable rootCause = e.getRootCause();
         if (rootCause instanceof BoombimException babException) {
             return ResponseEntity
-                    .status(babException.getHttpStatusCode())
-                    .body(ErrorResponse.of(babException));
+                .status(babException.getHttpStatusCode())
+                .body(ErrorResponse.of(babException));
         }
 
         return ResponseEntity
-                .status(400)
-                .body(ErrorResponse.of(ErrorCode.PARAMETER_GRAMMAR_ERROR, rootCause != null ? rootCause.getMessage() : "잘못된 요청입니다."));
+            .status(400)
+            .body(ErrorResponse.of(ErrorCode.PARAMETER_GRAMMAR_ERROR, rootCause != null ? rootCause.getMessage() : "잘못된 요청입니다."));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -55,7 +70,7 @@ public class GlobalExceptionHandler {
         Map<String, String> errors = new HashMap<>();
 
         ex.getBindingResult().getFieldErrors().forEach(error ->
-                errors.put(error.getField(), error.getDefaultMessage())
+            errors.put(error.getField(), error.getDefaultMessage())
         );
 
         return ResponseEntity.badRequest().body(errors);

--- a/src/main/java/boombimapi/global/infra/exception/auth/BoombimAuthExceptionFilter.java
+++ b/src/main/java/boombimapi/global/infra/exception/auth/BoombimAuthExceptionFilter.java
@@ -3,7 +3,7 @@ package boombimapi.global.infra.exception.auth;
 
 import boombimapi.global.infra.exception.error.BoombimException;
 import boombimapi.global.infra.exception.error.ErrorCode;
-import boombimapi.global.infra.exception.error.ErrorResponse;
+import boombimapi.global.infra.exception.error.response.ErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/src/main/java/boombimapi/global/infra/exception/error/BoombimException.java
+++ b/src/main/java/boombimapi/global/infra/exception/error/BoombimException.java
@@ -2,20 +2,29 @@ package boombimapi.global.infra.exception.error;
 
 
 public class BoombimException extends RuntimeException {
+
     private final ErrorCode errorCode;
 
-    public BoombimException(ErrorCode errorCode) {
+    public BoombimException(
+        ErrorCode errorCode
+    ) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 
-    public BoombimException(ErrorCode errorCode, String detailMessage) {
+    public BoombimException(
+        ErrorCode errorCode,
+        String detailMessage
+    ) {
         super(errorCode.getMessage() + " → " + detailMessage);
         this.errorCode = errorCode;
     }
 
 
-    public BoombimException(ErrorCode errorCode, Throwable cause) {
+    public BoombimException(
+        ErrorCode errorCode,
+        Throwable cause
+    ) {
         super(errorCode.getMessage(), cause);
         this.errorCode = errorCode;
     }

--- a/src/main/java/boombimapi/global/infra/exception/error/ErrorCode.java
+++ b/src/main/java/boombimapi/global/infra/exception/error/ErrorCode.java
@@ -91,7 +91,8 @@ public enum ErrorCode {
     AI_ATTEMPT_TOKEN_PLACE_MISMATCH(-902, "AI 생성 토큰의 장소와 요청 값이 다릅니다.", 422),
     AI_ATTEMPT_TOKEN_NO_ACTIVE_POINTER(-903, "활성 AI 생성 토큰이 없습니다.", 406),
     AI_ATTEMPT_TOKEN_ALREADY_USED(-904, "AI 생성 토큰이 이미 사용되었습니다.", 409),
-    AI_ATTEMPT_TOKEN_SUPERSEDED(-905, "AI 생성 토큰이 이미 교체되었습니다.", 424);
+    AI_ATTEMPT_TOKEN_SUPERSEDED(-905, "AI 생성 토큰이 이미 교체되었습니다.", 424),
+    AI_ATTEMPT_RATE_LIMITED(-906, "AI 생성 요청이 너무 빠릅니다.", 429);
 
     private final int code;
     private final String message;

--- a/src/main/java/boombimapi/global/infra/exception/error/RateLimitedException.java
+++ b/src/main/java/boombimapi/global/infra/exception/error/RateLimitedException.java
@@ -1,0 +1,8 @@
+package boombimapi.global.infra.exception.error;
+
+public class RateLimitedException extends RuntimeException {
+
+    public RateLimitedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/boombimapi/global/infra/exception/error/RateLimitedException.java
+++ b/src/main/java/boombimapi/global/infra/exception/error/RateLimitedException.java
@@ -1,8 +1,20 @@
 package boombimapi.global.infra.exception.error;
 
+import lombok.Getter;
+
+@Getter
 public class RateLimitedException extends RuntimeException {
 
-    public RateLimitedException(String message) {
-        super(message);
+    private final ErrorCode errorCode;
+    private final long retryAfterSeconds;
+
+    public RateLimitedException(
+        ErrorCode errorCode,
+        long retryAfterSeconds
+    ) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.retryAfterSeconds = retryAfterSeconds;
     }
+
 }

--- a/src/main/java/boombimapi/global/infra/exception/error/response/ErrorResponse.java
+++ b/src/main/java/boombimapi/global/infra/exception/error/response/ErrorResponse.java
@@ -2,42 +2,69 @@ package boombimapi.global.infra.exception.error.response;
 
 import boombimapi.global.infra.exception.error.BoombimException;
 import boombimapi.global.infra.exception.error.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.time.LocalDateTime;
+import lombok.Builder;
 
-
+@Builder
+@JsonInclude(Include.NON_NULL)
 public record ErrorResponse(
-        int status,
-        int code,
-        String message,
-        LocalDateTime time
+    int status,
+    int code,
+    String message,
+    LocalDateTime time,
+
+    // optional
+    LocalDateTime retryAt
 ) {
-    public static ErrorResponse of(BoombimException exception) {
-        return new ErrorResponse(
-                exception.getHttpStatusCode(),
-                exception.getErrorCode().getCode(),
-                exception.getMessage(),
 
-                LocalDateTime.now()
-        );
+    public static ErrorResponse of(
+        BoombimException e
+    ) {
+        return ErrorResponse.builder()
+            .status(e.getHttpStatusCode())
+            .code(e.getErrorCode().getCode())
+            .message(e.getMessage())
+            .time(LocalDateTime.now())
+            .build();
     }
 
-    public static ErrorResponse of(ErrorCode errorCode) {
-        return new ErrorResponse(
-                errorCode.getHttpCode(),
-                errorCode.getCode(),
-                errorCode.getMessage(),
-
-                LocalDateTime.now()
-        );
+    public static ErrorResponse of(
+        ErrorCode errorCode
+    ) {
+        return ErrorResponse.builder()
+            .status(errorCode.getHttpCode())
+            .code(errorCode.getCode())
+            .message(errorCode.getMessage())
+            .time(LocalDateTime.now())
+            .build();
     }
 
-    public static ErrorResponse of(ErrorCode errorCode, String customMessage) {
-        return new ErrorResponse(
-                errorCode.getHttpCode(),
-                errorCode.getCode(),
-                customMessage,
-
-                LocalDateTime.now()
-        );
+    public static ErrorResponse of(
+        ErrorCode errorCode,
+        String customMessage
+    ) {
+        return ErrorResponse.builder()
+            .status(errorCode.getHttpCode())
+            .code(errorCode.getCode())
+            .message(customMessage)
+            .time(LocalDateTime.now())
+            .build();
     }
+
+    public static ErrorResponse of(
+        ErrorCode errorCode,
+        LocalDateTime now,
+        LocalDateTime retryAt
+    ) {
+        return ErrorResponse.builder()
+            .status(errorCode.getHttpCode())
+            .code(errorCode.getCode())
+            .message(errorCode.getMessage())
+            .time(now)
+            .retryAt(retryAt)
+            .build();
+    }
+
 }

--- a/src/main/java/boombimapi/global/infra/exception/error/response/ErrorResponse.java
+++ b/src/main/java/boombimapi/global/infra/exception/error/response/ErrorResponse.java
@@ -1,5 +1,7 @@
-package boombimapi.global.infra.exception.error;
+package boombimapi.global.infra.exception.error.response;
 
+import boombimapi.global.infra.exception.error.BoombimException;
+import boombimapi.global.infra.exception.error.ErrorCode;
 import java.time.LocalDateTime;
 
 

--- a/src/main/java/boombimapi/global/infra/exception/error/response/RateLimitedErrorResponse.java
+++ b/src/main/java/boombimapi/global/infra/exception/error/response/RateLimitedErrorResponse.java
@@ -1,0 +1,5 @@
+package boombimapi.global.infra.exception.error.response;
+
+public record RateLimitedErrorResponse() {
+
+}

--- a/src/main/java/boombimapi/global/infra/exception/error/response/RateLimitedErrorResponse.java
+++ b/src/main/java/boombimapi/global/infra/exception/error/response/RateLimitedErrorResponse.java
@@ -1,5 +1,0 @@
-package boombimapi.global.infra.exception.error.response;
-
-public record RateLimitedErrorResponse() {
-
-}

--- a/src/main/java/boombimapi/global/infra/ratelimit/AiAttemptTokenBucketLimiter.java
+++ b/src/main/java/boombimapi/global/infra/ratelimit/AiAttemptTokenBucketLimiter.java
@@ -1,5 +1,60 @@
 package boombimapi.global.infra.ratelimit;
 
+import boombimapi.global.properties.AiAttemptTokenBucketProperties;
+import boombimapi.global.vo.AiAttemptRateLimitDecision;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class AiAttemptTokenBucketLimiter {
+
+    private final ObjectMapper objectMapper;
+    private final StringRedisTemplate redisTemplate;
+    private final AiAttemptTokenBucketProperties properties;
+    private final DefaultRedisScript<String> aiAttemptTokenBucketScript;
+
+    public AiAttemptRateLimitDecision checkAndConsume(
+        String memberId,
+        int cost
+    ) {
+
+        final String tokenBucketKey = tokenBucketKey(memberId);
+
+        try {
+            String json = redisTemplate.execute(
+                aiAttemptTokenBucketScript,
+                List.of(tokenBucketKey),
+                String.valueOf(properties.capacity()),
+                String.valueOf(properties.refillPerSecond()),
+                String.valueOf(cost),
+                String.valueOf(properties.idleTtlSeconds())
+            );
+
+            if (json == null) {
+                log.warn("[RateLimit] Redis returned null. Degrading to OPEN. memberId={}", memberId);
+                return new AiAttemptRateLimitDecision(true, 0L, properties.capacity());
+            }
+
+            return objectMapper.readValue(json, AiAttemptRateLimitDecision.class);
+
+        } catch (Exception e) {
+            log.error("[RateLimit] Lua execute → parse failed → OPEN. memberId: {}, error: {}", memberId, e.toString());
+            return new AiAttemptRateLimitDecision(true, 0L, properties.capacity());
+        }
+
+    }
+
+    private String tokenBucketKey(
+        String memberId
+    ) {
+        return "ai:token-bucket:" + memberId;
+    }
 
 }

--- a/src/main/java/boombimapi/global/infra/ratelimit/AiAttemptTokenBucketLimiter.java
+++ b/src/main/java/boombimapi/global/infra/ratelimit/AiAttemptTokenBucketLimiter.java
@@ -1,0 +1,5 @@
+package boombimapi.global.infra.ratelimit;
+
+public class AiAttemptTokenBucketLimiter {
+
+}

--- a/src/main/java/boombimapi/global/properties/AiAttemptTokenBucketProperties.java
+++ b/src/main/java/boombimapi/global/properties/AiAttemptTokenBucketProperties.java
@@ -1,5 +1,8 @@
 package boombimapi.global.properties;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "rate-limit.ai.token-bucket")
 public record AiAttemptTokenBucketProperties(
     int capacity,
     double refillPerSecond,

--- a/src/main/java/boombimapi/global/properties/AiAttemptTokenBucketProperties.java
+++ b/src/main/java/boombimapi/global/properties/AiAttemptTokenBucketProperties.java
@@ -1,0 +1,5 @@
+package boombimapi.global.properties;
+
+public record AiAttemptTokenBucketProperties() {
+
+}

--- a/src/main/java/boombimapi/global/properties/AiAttemptTokenBucketProperties.java
+++ b/src/main/java/boombimapi/global/properties/AiAttemptTokenBucketProperties.java
@@ -1,5 +1,10 @@
 package boombimapi.global.properties;
 
-public record AiAttemptTokenBucketProperties() {
+public record AiAttemptTokenBucketProperties(
+    int capacity,
+    double refillPerSecond,
+    int idleTtlSeconds,
+    int defaultCost
+) {
 
 }

--- a/src/main/java/boombimapi/global/vo/AiAttemptRateLimitDecision.java
+++ b/src/main/java/boombimapi/global/vo/AiAttemptRateLimitDecision.java
@@ -1,5 +1,13 @@
 package boombimapi.global.vo;
 
-public record AiAttemptRateLimitDecision() {
+public record AiAttemptRateLimitDecision(
+    boolean allowed,
+    long retryAfterMs,
+    double tokensLeft
+) {
+
+    public long retryAfterSeconds() {
+        return Math.max(1, retryAfterMs / 1000);
+    }
 
 }

--- a/src/main/java/boombimapi/global/vo/AiAttemptRateLimitDecision.java
+++ b/src/main/java/boombimapi/global/vo/AiAttemptRateLimitDecision.java
@@ -1,0 +1,5 @@
+package boombimapi.global.vo;
+
+public record AiAttemptRateLimitDecision() {
+
+}

--- a/src/main/java/boombimapi/global/vo/Coordinate.java
+++ b/src/main/java/boombimapi/global/vo/Coordinate.java
@@ -1,4 +1,4 @@
-package boombimapi.global.dto;
+package boombimapi.global.vo;
 
 public record Coordinate(
     double latitude,

--- a/src/main/resources/lua/ai_attempt_token_bucket.lua
+++ b/src/main/resources/lua/ai_attempt_token_bucket.lua
@@ -1,0 +1,45 @@
+-- KEYS[1] = ai:{memberId}:token-bucket
+-- ARGV[1]=capacity, ARGV[2]=refillPerSec, ARGV[3]=cost, ARGV[4]=idleTtlSec
+local t = redis.call('TIME')
+local nowMs = t[1] * 1000 + math.floor(t[2] / 1000)
+
+local cap = tonumber(ARGV[1])
+local refillSec = tonumber(ARGV[2])
+local cost = tonumber(ARGV[3])
+local ttlSec = tonumber(ARGV[4])
+
+local vals = redis.call('HMGET', KEYS[1], 'tokens', 'ts')
+local tokens = tonumber(vals[1])
+local ts = tonumber(vals[2])
+if not tokens then
+    tokens = cap;
+    ts = nowMs
+end
+
+local elapsedMs = nowMs - ts
+if elapsedMs < 0 then
+    elapsedMs = 0
+end
+tokens = math.min(cap, tokens + (elapsedMs / 1000.0) * refillSec)
+
+local allowed = false
+local retryAfterMs = 0
+
+if tokens + 1e-9 >= cost then
+    allowed = true
+    tokens = tokens - cost
+else
+    if refillSec <= 0 then
+        retryAfterMs = 60000
+    else
+        local need = (cost - tokens)
+        retryAfterMs = math.floor((need / refillSec) * 1000)
+    end
+end
+
+redis.call('HMSET', KEYS[1], 'tokens', tostring(tokens), 'ts', tostring(nowMs))
+if ttlSec > 0 then
+    redis.call('EXPIRE', KEYS[1], ttlSec)
+end
+
+return cjson.encode({ allowed = allowed, retryAfterMs = retryAfterMs, tokensLeft = tokens })


### PR DESCRIPTION
## #️⃣연관된 이슈

- #111 

## 📝작업 내용

사용자의 무분별한 AI 메시지 생성 시도를 방어하기 위해 서버 단에 Token Bucket을 적용했습니다.

