### PR TITLE
[Refactor] 토큰 중복 로직 개선

### DIFF
--- a/src/main/java/boombimapi/domain/alarm/application/service/impl/FcmServiceImpl.java
+++ b/src/main/java/boombimapi/domain/alarm/application/service/impl/FcmServiceImpl.java
@@ -43,12 +43,25 @@ public class FcmServiceImpl implements FcmService {
     public void registerToken(Member user, String token, DeviceType deviceType) {
         try {
             // 기존 토큰이 있는지 확인
-            Optional<FcmToken> existingToken = fcmTokenRepository.findByMemberIdAndToken(user.getId(), token);
+            // Optional<FcmToken> existingToken = fcmTokenRepository.findByMemberIdAndToken(user.getId(), token);
 
-            if (existingToken.isPresent()) {
+            List<FcmToken> existingToken = fcmTokenRepository.findAllByToken(token);
+
+            if (!existingToken.isEmpty()) {
                 // 기존 토큰이 있으면 활성화 및 마지막 사용 시간 업데이트
-                FcmToken fcmToken = existingToken.get();
-                fcmToken.activate();
+                if (existingToken.size() == 1) {
+                    FcmToken fcmToken = existingToken.get(0);
+                    fcmToken.activate();
+                } else {
+                    for (FcmToken findFcmToken : existingToken) {
+                        if (findFcmToken.getMember().getId().equals(user.getId())) {
+                            findFcmToken.activate();
+                        } else {
+                            fcmTokenRepository.deleteAllByMember(findFcmToken.getMember());
+                        }
+                    }
+                }
+
                 log.info("기존 FCM 토큰 활성화: userId={}, deviceType={}", user.getId(), deviceType);
             } else {
                 // 새로운 토큰 생성
@@ -278,7 +291,7 @@ public class FcmServiceImpl implements FcmService {
     @Override
     public void deleteFcmToken(String userId) {
         Member member = memberRepository.findById(userId).orElse(null);
-        if(member == null) throw new BoombimException(ErrorCode.USER_NOT_EXIST);
+        if (member == null) throw new BoombimException(ErrorCode.USER_NOT_EXIST);
 
         fcmTokenRepository.deleteAllByMember(member);
     }

--- a/src/main/java/boombimapi/domain/alarm/domain/repository/FcmTokenRepository.java
+++ b/src/main/java/boombimapi/domain/alarm/domain/repository/FcmTokenRepository.java
@@ -34,8 +34,13 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
     // 토큰으로 조회
     Optional<FcmToken> findByToken(String token);
 
+    // 중복 가능 토큰 조회 (List)
+    List<FcmToken> findAllByToken(String token);
+
     // 사용자와 토큰으로 조회
     Optional<FcmToken> findByMemberIdAndToken(String userId, String token);
+
+
 
     // 비활성화된 토큰 삭제
     @Modifying


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #126 

## 📝작업 내용

> findByToken 을 단일 조회용과 중복 조회용으로 분리하여 findAllByToken 메서드를 추가함.

> FCM 토큰 중복을 방지하기 위한 로직을 개선하여 저장/조회 시 충돌을 예방함.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?