### PR TITLE
[Feat] 이벤트 캠페인 등록 API 개발

### DIFF
--- a/src/main/java/boombimapi/domain/member/domain/entity/Member.java
+++ b/src/main/java/boombimapi/domain/member/domain/entity/Member.java
@@ -80,10 +80,6 @@ public class Member {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PointHistory> pointHistories = new ArrayList<>();
 
-    // 11) 이벤트 응모
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<EventCampaign> eventCampaigns = new ArrayList<>();
-
     // 11) 이벤트 로그
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<EventLog> eventLogs = new ArrayList<>();

--- a/src/main/java/boombimapi/domain/point/application/PointService.java
+++ b/src/main/java/boombimapi/domain/point/application/PointService.java
@@ -1,6 +1,7 @@
 package boombimapi.domain.point.application;
 
 import boombimapi.domain.member.domain.entity.Member;
+import boombimapi.domain.point.presentation.dto.req.CreateEventCampaignReq;
 import boombimapi.domain.point.presentation.dto.req.UsePointForEventReq;
 import boombimapi.domain.point.presentation.dto.res.EventPageRes;
 import boombimapi.domain.point.presentation.dto.res.GetPointRes;
@@ -44,4 +45,6 @@ public interface PointService {
 
 
     EventPageRes getOngoingEventPage();
+
+    void createEventCampaign(CreateEventCampaignReq req);
 }

--- a/src/main/java/boombimapi/domain/point/application/impl/PointServiceImpl.java
+++ b/src/main/java/boombimapi/domain/point/application/impl/PointServiceImpl.java
@@ -14,6 +14,7 @@ import boombimapi.domain.point.domain.repository.EventCampaignRepository;
 import boombimapi.domain.point.domain.repository.EventLogRepository;
 import boombimapi.domain.point.domain.repository.PointHistoryRepository;
 import boombimapi.domain.point.domain.repository.PointRepository;
+import boombimapi.domain.point.presentation.dto.req.CreateEventCampaignReq;
 import boombimapi.domain.point.presentation.dto.req.UsePointForEventReq;
 import boombimapi.domain.point.presentation.dto.res.EventPageRes;
 import boombimapi.domain.point.presentation.dto.res.GetPointHistoryRes;
@@ -21,6 +22,7 @@ import boombimapi.domain.point.presentation.dto.res.GetPointRes;
 import boombimapi.global.infra.exception.error.BoombimException;
 import boombimapi.global.infra.exception.error.ErrorCode;
 import jakarta.transaction.Transactional;
+import jdk.jfr.Event;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -153,5 +155,17 @@ public class PointServiceImpl implements PointService {
         if(eventCampaign == null) throw new BoombimException(EVENT_NOT_EXIST);
 
         return EventPageRes.of(eventCampaign);
+    }
+
+    @Override
+    public void createEventCampaign(CreateEventCampaignReq req) {
+        EventCampaign eventCampaign = EventCampaign.builder()
+                .eventStartDate(req.eventStartDate())
+                .eventEndDate(req.eventEndDate())
+                .winnerAnnouncementDate(req.winnerAnnouncementDate())
+                .eventCategory(req.eventCategory())
+                .build();
+
+        eventCampaignRepository.save(eventCampaign);
     }
 }

--- a/src/main/java/boombimapi/domain/point/domain/entity/EventCampaign.java
+++ b/src/main/java/boombimapi/domain/point/domain/entity/EventCampaign.java
@@ -38,10 +38,6 @@ public class EventCampaign {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
-
     @OneToMany(mappedBy = "eventCampaign", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<EventLog> eventlogs = new ArrayList<>();
 
@@ -68,10 +64,9 @@ public class EventCampaign {
     private LocalDateTime createdAt;
 
     @Builder
-    public EventCampaign(Member member, EventCategory eventCategory,
+    public EventCampaign(EventCategory eventCategory,
                          LocalDateTime eventStartDate, LocalDateTime eventEndDate,
                          LocalDateTime winnerAnnouncementDate) {
-        this.member = member;
         this.eventCategory = eventCategory;
         this.eventStartDate = eventStartDate;
         this.eventEndDate = eventEndDate;

--- a/src/main/java/boombimapi/domain/point/presentation/controller/PointController.java
+++ b/src/main/java/boombimapi/domain/point/presentation/controller/PointController.java
@@ -1,6 +1,8 @@
 package boombimapi.domain.point.presentation.controller;
 
 import boombimapi.domain.point.application.PointService;
+import boombimapi.domain.point.domain.entity.type.EventCategory;
+import boombimapi.domain.point.presentation.dto.req.CreateEventCampaignReq;
 import boombimapi.domain.point.presentation.dto.req.UsePointForEventReq;
 import boombimapi.domain.point.presentation.dto.res.EventPageRes;
 import boombimapi.domain.point.presentation.dto.res.GetPointRes;
@@ -72,9 +74,7 @@ public class PointController {
     /**
      * [GET] 진행 중인 이벤트 페이지 조회 API
      * <p>
-     * - 현재 진행 중인 이벤트 캠페인을 조회한다.<br>
-     * - 가장 최근 생성된 이벤트 캠페인 기준으로 데이터를 반환한다.<br>
-     * - 이벤트 기간(시작일, 종료일, 당첨자 발표일) 정보를 포함한다.
+     * - 현재 진행 중인 이벤트 캠페인을 조회한다.<br> - 가장 최근 생성된 이벤트 캠페인 기준으로 데이터를 반환한다.<br> - 이벤트 기간(시작일, 종료일, 당첨자 발표일) 정보를 포함한다.
      *
      * @return 진행 중인 이벤트 페이지 응답 DTO
      */
@@ -87,5 +87,28 @@ public class PointController {
     public ResponseEntity<EventPageRes> getOngoingEventPage() {
         return ResponseEntity.ok(pointService.getOngoingEventPage());
     }
+
+    /**
+     * [POST] 이벤트 캠페인 등록 API
+     * <p>
+     * - 새로운 이벤트 캠페인을 등록한다.<br>
+     * - 이벤트 시작일, 종료일, 당첨자 발표일, 카테고리 정보를 요청 본문으로 전달받는다.<br>
+     * - 성공 시 HTTP 200 OK를 반환한다.
+     *
+     * @param req 이벤트 캠페인 등록 요청 DTO
+     * @return HTTP 200 OK (등록 성공)
+     */
+    @Operation(summary = "[관리자 전용] 이벤트 캠페인 등록 API", description = "새로운 이벤트 캠페인을 등록합니다. (시작일, 종료일, 당첨자 발표일, 카테고리 포함)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "이벤트 캠페인 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @PostMapping("/event")
+    public ResponseEntity<Void> createEventCampaign(@RequestBody CreateEventCampaignReq req) {
+        pointService.createEventCampaign(req);
+        return ResponseEntity.ok().build();
+    }
+
 
 }

--- a/src/main/java/boombimapi/domain/point/presentation/dto/req/CreateEventCampaignReq.java
+++ b/src/main/java/boombimapi/domain/point/presentation/dto/req/CreateEventCampaignReq.java
@@ -1,0 +1,17 @@
+package boombimapi.domain.point.presentation.dto.req;
+
+import boombimapi.domain.point.domain.entity.type.EventCategory;
+import java.time.LocalDateTime;
+
+/**
+ * 이벤트 캠페인 등록 요청 DTO
+ * <p>
+ * - 이벤트 시작일, 종료일, 당첨자 발표일, 카테고리 정보를 포함한다.
+ */
+public record CreateEventCampaignReq(
+        LocalDateTime eventStartDate,
+        LocalDateTime eventEndDate,
+        LocalDateTime winnerAnnouncementDate,
+        EventCategory eventCategory
+) {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #129 

## 📝작업 내용

> 이벤트 캠페인 등록 API 개발 완료했습니다. 
> 이벤트 캠피엔 엔티티에서 member 외래키 지웠습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?